### PR TITLE
Replace Authorization.Core project reference with associated package reference.

### DIFF
--- a/Authorization.Core.Tests/Authorization.Core.Tests.csproj
+++ b/Authorization.Core.Tests/Authorization.Core.Tests.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Authorization.Core.UI\Authorization.Core.UI.csproj" />
     <ProjectReference Include="..\Authorization.Core\Authorization.Core.csproj" />
   </ItemGroup>
 

--- a/Authorization.Core.Tests/AuthorizationManagerTests.cs
+++ b/Authorization.Core.Tests/AuthorizationManagerTests.cs
@@ -1,7 +1,6 @@
 using Authorization.Core.Tests.Data;
 using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.Attributes;
-using CRFricke.Authorization.Core.UI;
 using CRFricke.Test.Support.Fakes;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -321,12 +320,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.UserManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
                     )
@@ -361,16 +360,16 @@ namespace Authorization.Core.Tests
         public async Task AuthorizationManagerTest12Async()
         {
             var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Id = SysUiGuids.Role.RoleManager, Name = nameof(SysUiGuids.Role.RoleManager) };
+            var role = new AppRole { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
             var expectedClaims = SysClaims.Role.DefinedClaims;
 
             var user = new AppUser("NewUser@StEmilian.com");
             user.Claims.Add(
-                new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(SysUiGuids.Role.RoleManager) }
+                new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(TestGuids.Role.RoleManager) }
                 );
             user.Claims.Add(
-                new IdentityUserClaim<string> { Id = 2, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(SysUiGuids.Role.UserManager) }
+                new IdentityUserClaim<string> { Id = 2, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(TestGuids.Role.UserManager) }
                 );
 
             var dbContext = Mock.Of<AppDbContext>(db =>
@@ -380,17 +379,17 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.UserManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
                     )
                 ).Returns(true);
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.RoleManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
                     )
@@ -426,13 +425,13 @@ namespace Authorization.Core.Tests
         public async Task AuthorizationManagerTest13Async()
         {
             var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
+            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
             var expectedClaims = SysClaims.Role.DefinedClaims;
 
             var user = new AppUser("NewUser@StEmilian.com");
             user.Claims.Add(
-                new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(SysUiGuids.Role.UserManager) }
+                new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = nameof(TestGuids.Role.UserManager) }
                 );
 
             var dbContext = Mock.Of<AppDbContext>(db =>
@@ -442,12 +441,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.UserManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
                     )
@@ -526,12 +525,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.RoleManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.RoleManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.RoleManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
                     )
@@ -574,12 +573,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.RoleManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.RoleManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.RoleManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
                     )
@@ -606,7 +605,7 @@ namespace Authorization.Core.Tests
         [Fact(DisplayName = "IsAuthorized returns True")]
         public async Task AuthorizationManagerTest17Async()
         {
-            var role = new AppRole { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
+            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
             var roleClaimCache = new Mock<RoleClaimCache>();
             roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
@@ -643,7 +642,7 @@ namespace Authorization.Core.Tests
         [Fact(DisplayName = "IsAuthorized returns False")]
         public async Task AuthorizationManagerTest18Async()
         {
-            var role = new AppRole { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
+            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
             var roleClaimCache = new Mock<RoleClaimCache>();
             roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
@@ -704,7 +703,7 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
@@ -744,7 +743,7 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
@@ -784,18 +783,18 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.UserManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
                     )
                 ).Returns(true);
 
-            var role = new AppRole { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
+            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
             var dbContext = Mock.Of<AppDbContext>(db =>
                 db.Set<AppRole>() == new[] { role }.AsQueryable().BuildMockDbSet().Object
                 );
@@ -835,7 +834,7 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
@@ -846,7 +845,7 @@ namespace Authorization.Core.Tests
             var logger = new TestLogger<AuthorizationManager>();
             var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
 
-            var resource = new AppRole() { Id = SysUiGuids.Role.RoleManager, Name = nameof(SysUiGuids.Role.RoleManager) };
+            var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Delete);
             var authContext = new AuthorizationHandlerContext(new List<IAuthorizationRequirement> { appClaimRequirement }, claimsPrincipal, resource);
 
@@ -875,7 +874,7 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.UserManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.UserManager }); }
                     )
                 ).Returns(true);
 
@@ -886,7 +885,7 @@ namespace Authorization.Core.Tests
             var logger = new TestLogger<AuthorizationManager>();
             var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
 
-            var resource = new AppRole() { Id = SysUiGuids.Role.RoleManager, Name = nameof(SysUiGuids.Role.RoleManager) };
+            var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.UpdateClaims);
             var authContext = new AuthorizationHandlerContext(new List<IAuthorizationRequirement> { appClaimRequirement }, claimsPrincipal, resource);
 
@@ -915,12 +914,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.RoleManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.RoleManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.RoleManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
                     )
@@ -956,12 +955,12 @@ namespace Authorization.Core.Tests
             var userRoleCache = new Mock<UserRoleCache>();
             userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
-                    (object key, out object value) => { value = new HashSet<string>(new[] { SysUiGuids.Role.RoleManager }); }
+                    (object key, out object value) => { value = new HashSet<string>(new[] { TestGuids.Role.RoleManager }); }
                     )
                 ).Returns(true);
 
             var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(SysUiGuids.Role.RoleManager, out It.Ref<object>.IsAny))
+            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny))
                 .Callback(new TryGetValueDelegate(
                     (object key, out object value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
                     )
@@ -975,7 +974,7 @@ namespace Authorization.Core.Tests
             var logger = new TestLogger<AuthorizationManager>();
             var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
 
-            var resource = new AppRole() { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
+            var resource = new AppRole() { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read, SysClaims.Role.UpdateClaims);
             var authContext = new AuthorizationHandlerContext(new List<IAuthorizationRequirement> { appClaimRequirement }, claimsPrincipal, resource);
 

--- a/Authorization.Core.Tests/TestGuids.cs
+++ b/Authorization.Core.Tests/TestGuids.cs
@@ -1,0 +1,35 @@
+﻿using CRFricke.Authorization.Core;
+using System.Collections.Generic;
+
+namespace Authorization.Core.Tests
+{
+    public class TestGuids
+    {
+        /// <summary>
+        /// The Guids of the system Roles.
+        /// </summary>
+        public class Role : IDefinesGuids
+        {
+            /// <summary>
+            /// The Guid assigned to the RoleManager Role.
+            /// </summary>
+            public const string RoleManager = "5e79c59c-b0c1-4857-8f3a-d99dbd1e099f";
+
+            /// <summary>
+            /// The Guid assigned to the UserManager Role.
+            /// </summary>
+            public const string UserManager = "d29ad18a-eaae-407c-8398-92a99182148a";
+
+            /// <summary>
+            /// Returns a list of all GUIDs defined for Role entities.
+            /// </summary>
+            public static readonly List<string> DefinedGuids = new List<string>
+            {
+                RoleManager, UserManager
+            };
+
+            ///<inheritdoc/>
+            List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        }
+    }
+}

--- a/Authorization.Core.UI/Authorization.Core.UI.csproj
+++ b/Authorization.Core.UI/Authorization.Core.UI.csproj
@@ -48,14 +48,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CRFricke.Authorization.Core" Version="1.0.0-beta2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Authorization.Core\Authorization.Core.csproj" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Removed "Authorization.Core" project reference

"Authorization.Core.Tests" project contained reference to "Authorization.Core.UI" project which is not under test. Removed reference and fixed up resulting errors.