### PR TITLE
Remove PrincipalId from log messages.

### DIFF
--- a/Authorization.Core.UI.Tests/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests/RoleManagementTests.cs
@@ -199,7 +199,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.NotNull(logger.LogEntries[0].Exception);
@@ -245,7 +244,6 @@ namespace Authorization.Core.UI.Tests
             Assert.NotNull(role);
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -427,7 +425,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -638,7 +635,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -840,7 +836,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(expectedMessage2, logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -905,7 +900,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -1019,7 +1013,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -1075,7 +1068,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(expectedMessage2, logger.LogEntries[0].Message);
             Assert.Contains(role.Id, logger.LogEntries[0].Message);
@@ -1231,7 +1223,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(expectedLogMessage, logger.LogEntries[0].Message);
             Assert.Null(logger.LogEntries[0].Exception);
@@ -1286,7 +1277,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationRole), logger.LogEntries[0].Message);
             Assert.Contains(role.Name, logger.LogEntries[0].Message);

--- a/Authorization.Core.UI.Tests/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests/UserManagementTests.cs
@@ -177,7 +177,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(user.Email, logger.LogEntries[0].Message);
@@ -273,7 +272,6 @@ namespace Authorization.Core.UI.Tests
             Assert.NotNull(user);
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains($"created {nameof(ApplicationUser)}", logger.LogEntries[0].Message);
             Assert.Contains(user.Id, logger.LogEntries[0].Message);
@@ -419,7 +417,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(users[0].Id, logger.LogEntries[0].Message);
@@ -612,7 +609,6 @@ namespace Authorization.Core.UI.Tests
             Assert.NotNull(user);
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(user.Id, logger.LogEntries[0].Message);
@@ -843,7 +839,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Error, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(user.Id, logger.LogEntries[0].Message);
@@ -941,7 +936,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Information, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(user.Id, logger.LogEntries[0].Message);
@@ -996,7 +990,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains("delete system", logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
@@ -1065,7 +1058,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(expectedLogMessage, logger.LogEntries[0].Message);
             Assert.Contains(user.Id, logger.LogEntries[0].Message);
@@ -1241,7 +1233,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalId, logger.LogEntries[0].Message);
             Assert.Contains(principalName, logger.LogEntries[0].Message);
             Assert.Contains(expectedLogMessage, logger.LogEntries[0].Message);
             Assert.Null(logger.LogEntries[0].Exception);
@@ -1305,7 +1296,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principalUser.Id, logger.LogEntries[0].Message);
             Assert.Contains(principalUser.UserName, logger.LogEntries[0].Message);
             Assert.Contains(nameof(ApplicationUser), logger.LogEntries[0].Message);
             Assert.Contains(user.Email, logger.LogEntries[0].Message);
@@ -1372,7 +1362,6 @@ namespace Authorization.Core.UI.Tests
 
             Assert.Single(logger.LogEntries);
             Assert.Equal(LogLevel.Warning, logger.LogEntries[0].LogLevel);
-            Assert.Contains(principal.Id, logger.LogEntries[0].Message);
             Assert.Contains(principal.UserName, logger.LogEntries[0].Message);
             Assert.Contains(expectedLogMessage, logger.LogEntries[0].Message);
             Assert.Null(logger.LogEntries[0].Exception);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
@@ -70,8 +70,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 ModelState.AddModelError(string.Empty, "You can not create a Role with more privileges than you have.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to create {RoleType} with elevated privileges.",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name
+                    "'{PrincipalEmail}' attempted to create {RoleType} with elevated privileges.",
+                    User.Identity.Name, typeof(TRole).Name
                     );
 
                 return Page();
@@ -88,8 +88,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -101,8 +101,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID: {PrincipalId}) created {RoleType} '{RoleName}' (ID: {RoleId}).",
-                User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                "'{PrincipalEmail}' created {RoleType} '{RoleName}' (ID: {RoleId}).",
+                User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
@@ -94,8 +94,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 ModelState.AddModelError(string.Empty, "System Roles may not be deleted.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                     User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    "'{PrincipalEmail}' attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -120,8 +120,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -142,8 +142,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID: {PrincipalId}) deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
-                User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                "'{PrincipalEmail}' deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
+                User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
@@ -108,8 +108,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                         ModelState.AddModelError(string.Empty, "You may not update the Claims assigned to a system Role.");
 
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                            User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                            "'{PrincipalEmail}' attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
+                            User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                             );
                         return Page();
                     }
@@ -117,8 +117,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                     ModelState.AddModelError(string.Empty, "You can not give a Role more privileges than you have.");
 
                     _logger.LogWarning(
-                        "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
-                        User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                        "'{PrincipalEmail}' attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
+                        User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                         );
                     return Page();
                 }
@@ -134,8 +134,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -154,8 +154,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role
                     );
 
                 _logger.LogInformation(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) updated {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    "'{PrincipalEmail}' updated {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
             }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
@@ -69,8 +69,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 ModelState.AddModelError(string.Empty, "You can not create a User with more privileges than you have.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to create {UserType} with elevated privileges.",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name
+                    "'{PrincipalEmail}' attempted to create {UserType} with elevated privileges.",
+                    User.Identity.Name, typeof(TUser).Name
                     );
 
                 return Page();
@@ -90,8 +90,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not create {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not create {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 return Page();
@@ -103,8 +103,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID '{PrincipalId}') created {UserType} '{UserEmail}' (ID '{UserId}').",
-                 User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                "'{PrincipalEmail}' created {UserType} '{UserEmail}' (ID '{UserId}').",
+                User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
@@ -97,8 +97,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 ModelState.AddModelError(string.Empty, "System accounts may not be deleted.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    "'{PrincipalEmail}' attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 await UserModel.InitRoleInfoAsync(_repository);
@@ -116,8 +116,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
             }
 
@@ -136,8 +136,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID '{PrincipalId}') deleted {UserType} '{UserEmail}' (ID '{UserId}').",
-                User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                "'{PrincipalEmail}' deleted {UserType} '{UserEmail}' (ID '{UserId}').",
+                User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
@@ -107,8 +107,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                         ModelState.AddModelError(string.Empty, "You may not update the Roles assigned to a system User.");
 
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
-                            User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                            "'{PrincipalEmail}' attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
+                            User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                             );
                         return Page();
                     }
@@ -117,16 +117,16 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                     {
                         ModelState.AddModelError(string.Empty, "You can not give a User more privileges than you have.");
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
-                            User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                            "'{PrincipalEmail}' attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
+                            User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                             );
                     }
                     else
                     {
                         ModelState.AddModelError(string.Empty, "You can not elevate your own privileges.");
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to elevate their own privileges.",
-                             User.Identity.Name, User.UserId()
+                            "'{PrincipalEmail}' attempted to elevate their own privileges.",
+                            User.Identity.Name
                             );
                     }
 
@@ -144,8 +144,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not update {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not update {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 return Page();
@@ -164,8 +164,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User
                     );
 
                 _logger.LogInformation(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') updated {UserType} '{UserEmail}' (ID '{UserId}').",
-                     User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    "'{PrincipalEmail}' updated {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
             }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
@@ -70,8 +70,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 ModelState.AddModelError(string.Empty, "You can not create a Role with more privileges than you have.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to create {RoleType} with elevated privileges.",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name
+                    "'{PrincipalEmail}' attempted to create {RoleType} with elevated privileges.",
+                    User.Identity.Name, typeof(TRole).Name
                     );
 
                 return Page();
@@ -88,8 +88,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -101,8 +101,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID: {PrincipalId}) created {RoleType} '{RoleName}' (ID: {RoleId}).",
-                User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                "'{PrincipalEmail}' created {RoleType} '{RoleName}' (ID: {RoleId}).",
+                User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
@@ -95,8 +95,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 ModelState.AddModelError(string.Empty, "System Roles may not be deleted.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                     User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    "'{PrincipalEmail}' attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 await RoleModel.InitRoleClaims(_authManager)
@@ -125,8 +125,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 await RoleModel.InitRoleClaims(_authManager)
@@ -151,8 +151,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID: {PrincipalId}) deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
-                User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                "'{PrincipalEmail}' deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
+                User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
@@ -108,16 +108,16 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                         var message = "You may not update the Claims assigned to a system Role.";
                         ModelState.AddModelError(string.Empty, message);
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                            User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                            "'{PrincipalEmail}' attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
+                            User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                             );
                         return Page();
                     }
 
                     ModelState.AddModelError(string.Empty, "You can not give a Role more privileges than you have.");
                     _logger.LogWarning(
-                        "'{PrincipalEmail}' (ID: {PrincipalId}) attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
-                        User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                        "'{PrincipalEmail}' attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
+                        User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                         );
                     return Page();
                 }
@@ -133,8 +133,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID: {PrincipalId}) could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    ex, "'{PrincipalEmail}' could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
 
                 return Page();
@@ -153,8 +153,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role
                     );
 
                 _logger.LogInformation(
-                    "'{PrincipalEmail}' (ID: {PrincipalId}) updated {RoleType} '{RoleName}' (ID: {RoleId}).",
-                    User.Identity.Name, User.UserId(), typeof(TRole).Name, role.Name, role.Id
+                    "'{PrincipalEmail}' updated {RoleType} '{RoleName}' (ID: {RoleId}).",
+                    User.Identity.Name, typeof(TRole).Name, role.Name, role.Id
                     );
             }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
@@ -69,8 +69,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 ModelState.AddModelError(string.Empty, "You can not create a User with more privileges than you have.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to create {UserType} with elevated privileges.",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name
+                    "'{PrincipalEmail}' attempted to create {UserType} with elevated privileges.",
+                    User.Identity.Name, typeof(TUser).Name
                     );
 
                 return Page();
@@ -90,8 +90,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not create {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not create {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 return Page();
@@ -103,8 +103,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID '{PrincipalId}') created {UserType} '{UserEmail}' (ID '{UserId}').",
-                 User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                "'{PrincipalEmail}' created {UserType} '{UserEmail}' (ID '{UserId}').",
+                User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
@@ -100,8 +100,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 ModelState.AddModelError(string.Empty, "System accounts may not be deleted.");
 
                 _logger.LogWarning(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    "'{PrincipalEmail}' attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 (await UserModel.InitRoleInfoAsync(_repository)).InitFromUser(user);
@@ -119,8 +119,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
             }
 
@@ -139,8 +139,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 );
 
             _logger.LogInformation(
-                "'{PrincipalEmail}' (ID '{PrincipalId}') deleted {UserType} '{UserEmail}' (ID '{UserId}').",
-                User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                "'{PrincipalEmail}' deleted {UserType} '{UserEmail}' (ID '{UserId}').",
+                User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return RedirectToPage(IndexModel.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
@@ -106,8 +106,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                     {
                         ModelState.AddModelError(string.Empty, "You may not update the Roles assigned to a system User.");
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
-                            User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                            "'{PrincipalEmail}' attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
+                            User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                             );
 
                         return Page();
@@ -117,16 +117,16 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                     {
                         ModelState.AddModelError(string.Empty, "You can not give a User more privileges than you have.");
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
-                            User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                            "'{PrincipalEmail}' attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
+                            User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                             );
                     }
                     else
                     {
                         ModelState.AddModelError(string.Empty, "You can not elevate your own privileges.");
                         _logger.LogWarning(
-                            "'{PrincipalEmail}' (ID '{PrincipalId}') attempted to elevate their own privileges.",
-                             User.Identity.Name, User.UserId()
+                            "'{PrincipalEmail}' attempted to elevate their own privileges.",
+                            User.Identity.Name
                             );
                     }
 
@@ -144,8 +144,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                 ModelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
                 _logger.LogError(
-                    ex, "'{PrincipalEmail}' (ID '{PrincipalId}') could not update {UserType} '{UserEmail}' (ID '{UserId}').",
-                    User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    ex, "'{PrincipalEmail}' could not update {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
 
                 return Page();
@@ -164,8 +164,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User
                     );
 
                 _logger.LogInformation(
-                    "'{PrincipalEmail}' (ID '{PrincipalId}') updated {UserType} '{UserEmail}' (ID '{UserId}').",
-                     User.Identity.Name, User.UserId(), typeof(TUser).Name, user.Email, user.Id
+                    "'{PrincipalEmail}' updated {UserType} '{UserEmail}' (ID '{UserId}').",
+                    User.Identity.Name, typeof(TUser).Name, user.Email, user.Id
                     );
             }
 


### PR DESCRIPTION
Principal Email is enough to uniquely identify the user performing the action.