### PR TITLE
Emulate NuGet processing of Core.UI package during compile.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,4 +51,4 @@ jobs:
     - name: Display Core.UI obj folder contents
       if: ${{ failure() }}
       shell: pwsh
-      run: Get-ChildItem -Path Authorization.Core.UI\obj -Recurse
+      run: Get-ChildItem -Path Authorization.Core.UI\obj -Name -Recurse

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,9 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-            6.0.x
-            7.0.x
+        dotnet-version: 6.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:
@@ -49,3 +47,8 @@ jobs:
 
     - name: Test
       run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal
+
+    - name: Display Core.UI obj folder contents
+      if: ${{ failure() }}
+      shell: pwsh
+      run: Get-ChildItem -Path Authorization.Core.UI\obj -Recurse

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,8 +47,3 @@ jobs:
 
     - name: Test
       run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal
-
-    - name: Display Core.UI obj folder contents
-      if: ${{ failure() }}
-      shell: pwsh
-      run: Get-ChildItem -Path Authorization.Core.UI\obj -Name -Recurse

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,7 +33,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+            6.0.x
+            7.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -53,11 +53,6 @@ jobs:
     - name: Upload Authorization.Core NuGet package to GitHub
       run: dotnet nuget push "**/CRFricke.Authorization.Core.*.nupkg" --source https://nuget.pkg.github.com/CRFricke/index.json --api-key ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Update Authorization.Core References
-      run: |
-        dotnet remove **/Authorization.Core.UI.csproj reference **/Authorization.Core.csproj
-        dotnet add **/Authorization.Core.UI.csproj package CRFricke.Authorization.Core --version $BUILD_VERSION --source https://nuget.pkg.github.com/CRFricke/index.json
-
     - name: Create Authorization.Core.UI NuGet package
       run: dotnet pack **/Authorization.Core.UI.csproj --configuration $BUILD_CONFIG --no-build /p:Version=$BUILD_VERSION
 

--- a/.gitignore
+++ b/.gitignore
@@ -361,4 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Authorization.Core project items
 /Authorization.Core.UI.Test.Web/Test.Web.db*
+/Authorization.Core.UI.Test.Web/wwwroot/_content

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Authorization.Core.UI.Test.Web</title>
     <link rel="stylesheet" type="text/css" href="~/lib/bootstrap/dist/css/bootstrap.min.css" asp-append-version="true" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs5/dt-1.12.1/datatables.min.css" />
+    <link rel="stylesheet" type="text/css" href="~/_content/CRFricke.Authorization.Core.UI/lib/datatables/datatables.min.css" asp-append-version="true" />
     <link rel="stylesheet" type="text/css" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" type="text/css" href="~/Authorization.Core.UI.Test.Web.styles.css" asp-append-version="true" />
 </head>
@@ -50,10 +50,10 @@
         </div>
     </footer>
 
-    <script src="~/lib/jquery/dist/jquery.min.js" asp-append-version="true"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js" asp-append-version="true"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/bs5/dt-1.12.1/datatables.min.js"></script>
-    <script src="~/js/site.js" asp-append-version="true"></script>
+    <script type="text/javascript" src="~/lib/jquery/dist/jquery.min.js" asp-append-version="true"></script>
+    <script type="text/javascript" src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js" asp-append-version="true"></script>
+    <script type="text/javascript" src="~/_content/CRFricke.Authorization.Core.UI/lib/datatables/datatables.min.js" asp-append-version="true"></script>
+    <script type="text/javascript" src="~/js/site.js" asp-append-version="true"></script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml
@@ -46,7 +46,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2022 - Authorization.Core.UI.Test.Web - <a asp-area="" asp-page="/Privacy">Privacy</a>
+            &copy; @DateTime.Now.Year - Authorization.Core.UI.Test.Web - <a asp-area="" asp-page="/Privacy">Privacy</a>
         </div>
     </footer>
 

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml.css
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Shared/_Layout.cshtml.css
@@ -1,0 +1,48 @@
+﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+for details on configuring this project to bundle and minify static web assets. */
+
+a.navbar-brand {
+  white-space: normal;
+  text-align: center;
+  word-break: break-all;
+}
+
+a {
+  color: #0077cc;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.nav-pills .nav-link.active, .nav-pills .show > .nav-link {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.border-top {
+  border-top: 1px solid #e5e5e5;
+}
+.border-bottom {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.box-shadow {
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
+}
+
+button.accept-policy {
+  font-size: 1rem;
+  line-height: inherit;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 60px;
+}

--- a/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
+++ b/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
@@ -39,7 +39,7 @@
     <_CoreUiProjectBundleName>$(_CoreUiPackageName).bundle.scp.css</_CoreUiProjectBundleName>
   </PropertyGroup>
 
-  <Target Name="CopyCoreUiAssets" BeforeTargets="PreBuildEvent">
+  <Target Name="CopyCoreUiAssets">
 
     <PropertyGroup>
       <_CoreUiContentPath>$(MSBuildThisFileDirectory)wwwroot\_content\$(_CoreUiPackageName)</_CoreUiContentPath>
@@ -60,7 +60,7 @@
     Now we need to add/fixup the @import statement at the beginning of this project's scoped CSS bundle.
   -->
 
-  <Target Name="FixupScopedCssBundle" AfterTargets="PostBuildEvent">
+  <Target Name="FixupScopedCssBundle" DependsOnTargets="CopyCoreUiAssets" AfterTargets="PostBuildEvent">
 
     <PropertyGroup>
       <_SearchText>_content/$(MSBuildProjectName)/_content</_SearchText>

--- a/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
+++ b/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -22,5 +22,61 @@
   <ItemGroup>
     <ProjectReference Include="..\Authorization.Core.UI\Authorization.Core.UI.csproj" />
   </ItemGroup>
+
+  <!--
+  *************************************************************************************************
+
+   Since we are not using a PackageReference to include the Authorization.Core.UI project, we need 
+   to manually copy the items that would normally be added in "~/wwwroot/_content" by NuGet. 
+      
+  *************************************************************************************************
+  -->
+
+  <PropertyGroup>
+    <_CoreUiProjectName>Authorization.Core.UI</_CoreUiProjectName>
+    <_CoreUiPackageName>CRFricke.$(_CoreUiProjectName)</_CoreUiPackageName>
+    <_CoreUiProjectPath>$(MSBuildStartupDirectory)\$(_CoreUiProjectName)</_CoreUiProjectPath>
+    <_CoreUiProjectBundleName>$(_CoreUiPackageName).bundle.scp.css</_CoreUiProjectBundleName>
+  </PropertyGroup>
+
+  <Target Name="CopyCoreUiAssets" BeforeTargets="PreBuildEvent">
+
+    <PropertyGroup>
+      <_CoreUiContentPath>$(MSBuildThisFileDirectory)wwwroot\_content\$(_CoreUiPackageName)</_CoreUiContentPath>
+      <_CoreUiCssBundlePath>$(_CoreUiProjectPath)\$(IntermediateOutputPath)scopedcss\projectbundle\$(_CoreUiProjectBundleName)</_CoreUiCssBundlePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_AssetItems Condition="'$(IdentityDefaultUIFramework)' == 'Bootstrap4'" Include="$(_CoreUiProjectPath)\assets\BS4\**" />
+      <_AssetItems Condition="'$(IdentityDefaultUIFramework)' != 'Bootstrap4'" Include="$(_CoreUiProjectPath)\assets\BS5\**" />
+      <_AssetItems Include="$(_CoreUiCssBundlePath)" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_AssetItems)" DestinationFiles="$(_CoreUiContentPath)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+    
+  </Target>
+
+  <!--
+    Now we need to add/fixup the @import statement at the beginning of this project's scoped CSS bundle.
+  -->
+
+  <Target Name="FixupScopedCssBundle" AfterTargets="PostBuildEvent">
+
+    <PropertyGroup>
+      <_SearchText>_content/$(MSBuildProjectName)/_content</_SearchText>
+      <_ReplaceText>_content</_ReplaceText>
+      <_BundlePath>$(MSBuildThisFileDirectory)$(IntermediateOutputPath)scopedcss\bundle\$(MSBuildProjectName).styles.css</_BundlePath>
+      <_BundleText>$([System.IO.File]::ReadAllText($(_BundlePath)).Replace($(_SearchText), $(_ReplaceText)))</_BundleText>
+      <_ImportStatement>@import '_content/$(_CoreUiPackageName)/$(_CoreUiProjectBundleName)'%3B</_ImportStatement>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_BundleLines Condition="$(_BundleText.StartsWith(&quot;@import&quot;)) == false" Include="$(_ImportStatement)" />
+      <_BundleLines Include="$(_BundleText)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(_BundlePath)" Lines="@(_BundleLines)" Overwrite="true" />
+
+  </Target>
 
 </Project>

--- a/Authorization.Core.UI.Test.Web/Pages/Shared/_Layout.cshtml
+++ b/Authorization.Core.UI.Test.Web/Pages/Shared/_Layout.cshtml
@@ -43,7 +43,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2022 - Authorization.Core.UI.Test.Web - <a asp-area="" asp-page="/Privacy">Privacy</a>
+            &copy; @DateTime.Now.Year - Authorization.Core.UI.Test.Web - <a asp-area="" asp-page="/Privacy">Privacy</a>
         </div>
     </footer>
 

--- a/Authorization.Core.UI.Test.Web/Startup.cs
+++ b/Authorization.Core.UI.Test.Web/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Authorization.Core.UI.Test.Web
 {
     /// <summary>
-    /// Contains the configuration routines for the web appliction.
+    /// Contains the configuration routines for the web application.
     /// </summary>
     /// <remarks>
     /// IMPORTANT: When using the .Net 6.0 minimal API, configuration is performed in Program.cs. 

--- a/Authorization.Core.UI/Authorization.Core.UI.csproj
+++ b/Authorization.Core.UI/Authorization.Core.UI.csproj
@@ -156,8 +156,4 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="dir /S" />
-  </Target>
-
 </Project>

--- a/Authorization.Core.UI/Authorization.Core.UI.csproj
+++ b/Authorization.Core.UI/Authorization.Core.UI.csproj
@@ -105,13 +105,7 @@
       </ReferenceAssetCandidates>
     </ItemGroup>
     
-    <DefineStaticWebAssets Condition="'@(ReferenceAssetCandidates->Count())' != '0'" 
-      CandidateAssets="@(ReferenceAssetCandidates)" 
-      SourceId="$(PackageId)" 
-      SourceType="Project" 
-      AssetKind="All" 
-      BasePath="$(StaticWebAssetBasePath)"
-    >
+    <DefineStaticWebAssets Condition="'@(ReferenceAssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(ReferenceAssetCandidates)" SourceId="$(PackageId)" SourceType="Project" AssetKind="All" BasePath="$(StaticWebAssetBasePath)">
       <Output TaskParameter="Assets" ItemName="ReferenceAsset" />
     </DefineStaticWebAssets>
     <ItemGroup>
@@ -134,27 +128,11 @@
       </BS5AssetCandidates>
     </ItemGroup>
     
-    <DefineStaticWebAssets 
-      Condition="'@(BS4AssetCandidates-&gt;Count())' != '0'" 
-      CandidateAssets="@(BS4AssetCandidates)" 
-      SourceId="$(PackageId)" 
-      SourceType="Discovered" 
-      AssetKind="All" 
-      ContentRoot="assets/BS4" 
-      BasePath="$(StaticWebAssetBasePath)"
-    >
+    <DefineStaticWebAssets Condition="'@(BS4AssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(BS4AssetCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/BS4" BasePath="$(StaticWebAssetBasePath)">
       <Output TaskParameter="Assets" ItemName="BS4Assets" />
     </DefineStaticWebAssets>
     
-    <DefineStaticWebAssets 
-      Condition="'@(BS5AssetCandidates-&gt;Count())' != '0'" 
-      CandidateAssets="@(BS5AssetCandidates)" 
-      SourceId="$(PackageId)" 
-      SourceType="Discovered" 
-      AssetKind="All" 
-      ContentRoot="assets/BS5" 
-      BasePath="$(StaticWebAssetBasePath)"
-    >
+    <DefineStaticWebAssets Condition="'@(BS5AssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(BS5AssetCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/BS5" BasePath="$(StaticWebAssetBasePath)">
       <Output TaskParameter="Assets" ItemName="BS5Assets" />
     </DefineStaticWebAssets>
 
@@ -176,6 +154,10 @@
         <PackagePath>build\Microsoft.AspNetCore.StaticWebAssets.BS5.targets</PackagePath>
       </StaticWebAssetPackageFile>
     </ItemGroup>
+  </Target>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="dir /S" />
   </Target>
 
 </Project>


### PR DESCRIPTION
The Core.UI package is included by project rather than package reference in the csproj file.

We create and populate the "~/_content/CRFricke.Authorization.Core.UI" folder and add the import statement for Core.UI's CSS bundle at the top of Core.UI.Test.Web's CSS bundle.