### PR TITLE
Fix AppRole rename issue.

### DIFF
--- a/Authorization.Core.Tests/AuthorizationManagerTests.cs
+++ b/Authorization.Core.Tests/AuthorizationManagerTests.cs
@@ -166,7 +166,7 @@ namespace Authorization.Core.Tests
         {
             var user = new AppUser("TestUser@StEmilian.com");
             var role = new AppRole() { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
-            var userClaim = new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Name };
+            var userClaim = new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Id };
             var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
 
             var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
@@ -34,6 +34,7 @@ namespace Authorization.Core.UI.Test.Web.Data
             await base.SeedDatabaseAsync(serviceProvider);
 
             var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
+            var hasher = serviceProvider.GetRequiredService<IPasswordHasher<ApplicationUser>>();
             var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<ApplicationDbContext>();
 
             var role = await Roles.FindAsync(AppGuids.Role.CalendarManager);
@@ -68,10 +69,10 @@ namespace Authorization.Core.UI.Test.Web.Data
                     LockoutEnabled = false,
                     NormalizedEmail = normalizer.NormalizeEmail(email),
                     NormalizedUserName = normalizer.NormalizeName(email),
-                    PasswordHash = "AQAAAAEAACcQAAAAEFXwSRmwaiwTjRDW4zcaupENlSdbverXypglebb + Ti6f / Rn4sBikU3q / uE0jJQJAMw ==", // "Calend@rGuy!"
+                    PasswordHash = hasher.HashPassword(user!, "Calend@rGuy!"),
                     Surname = "Guy",
                     UserName = email
-                }.SetClaims(new[] { role.Name! });
+                }.SetClaims([role.Id]);
 
                 await Users.AddAsync(user);
                 logger.LogInformation(
@@ -112,10 +113,10 @@ namespace Authorization.Core.UI.Test.Web.Data
                     LockoutEnabled = false,
                     NormalizedEmail = normalizer.NormalizeEmail(email),
                     NormalizedUserName = normalizer.NormalizeName(email),
-                    PasswordHash = "AQAAAAEAACcQAAAAEJaNzNSqF3SrSxUHuT010YO6kAmf95+Xv20mzd3MzLBTNU8ySBGMBqkx82q3Be+BCg==", // "D0cumentGuy!"
+                    PasswordHash = hasher.HashPassword(user!, "D0cumentGuy!"),
                     Surname = "Guy",
                     UserName = email
-                }.SetClaims(new[] { role.Name! });
+                }.SetClaims([role.Id]);
 
                 await Users.AddAsync(user);
                 logger.LogInformation(

--- a/Authorization.Core.UI.Tests.Playwright/Infrastructure/Extensions.cs
+++ b/Authorization.Core.UI.Tests.Playwright/Infrastructure/Extensions.cs
@@ -345,6 +345,19 @@ internal static class Extensions
     }
 
     /// <summary>
+    /// Returns the ApplicationRoles contained in the database.
+    /// </summary>
+    /// <param name="webAppFactory">
+    /// The <see cref="WebAppFactory"/> whose services are to be used to access the database.
+    /// </param>
+    /// <returns>A <see cref="DbSet{TEntity}"/> of the <see cref="ApplicationRole">ApplicationRoles</see> contained in the database.</returns>
+    internal static DbSet<ApplicationRole> GetRoles(this WebAppFactory webAppFactory)
+    {
+        var dbContext = webAppFactory.Services.GetRequiredService<ApplicationDbContext>();
+        return dbContext.Roles;
+    }
+
+    /// <summary>
     /// Retrieves the specified <see cref="ApplicationUser"/> from the database.  
     /// Returns <see langword="null"/> if there is no user with the specified email.
     /// </summary>

--- a/Authorization.Core.UI.Tests/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests/RoleManagementTests.cs
@@ -759,7 +759,7 @@ public class RoleManagementTests : TestsBase
         var user = new ApplicationUser { Email = "MrTester@company.com", UserName = "MrTester@company.com", GivenName = "Chuck", Surname = "Fricke" };
         var users = new List<ApplicationUser> { user }.AsQueryable().BuildMockDbSet();
 
-        var userClaim = new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Name };
+        var userClaim = new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Id };
         var userClaims = new List<IdentityUserClaim<string>> { userClaim }.AsQueryable().BuildMockDbSet();
 
         var authManager = Mock.Of<IAuthorizationManager>(am =>

--- a/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
@@ -95,14 +95,14 @@ public class RoleModel
         where TRole : AuthUiRole
         where TUser : AuthUiUser
     {
-        _ = Name ?? throw new InvalidOperationException(
+        _ = Id ?? throw new InvalidOperationException(
             $"{nameof(InitFromRole)} has not been called."
             );
 
         RoleUsers = await (
             from uc in repository.UserClaims
             join au in repository.Users on uc.UserId equals au.Id
-            where uc.ClaimType == ClaimTypes.Role && uc.ClaimValue == Name
+            where uc.ClaimType == ClaimTypes.Role && uc.ClaimValue == Id
             select new RoleUser { Name = au.DisplayName, Email = au.Email }
             ).ToListAsync();
 

--- a/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
@@ -147,7 +147,7 @@ namespace CRFricke.Authorization.Core.UI.Models
             return (
                 from role in Roles
                 where role.IsAssigned
-                select role.Name
+                select role.Id
                 ).ToArray();
         }
 
@@ -165,7 +165,7 @@ namespace CRFricke.Authorization.Core.UI.Models
 
             foreach (var role in Roles)
             {
-                role.IsAssigned = roles.Contains(role.Name);
+                role.IsAssigned = roles.Contains(role.Id);
             }
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
@@ -25,10 +25,10 @@ public abstract class IndexModel : ModelBase
                 {
                     if (_basePath is null)
                     {
-                        var path = Request.Path.Value;
+                        var path = Request.Path.Value.AsSpan();
                         _basePath = (
                             path.EndsWith(IndexHandler.PageName) ? path[..(path.Length - IndexHandler.PageName.Length)] : path
-                            ).TrimEnd('/');
+                            ).TrimEnd('/').ToString();
                     }
                 }
             }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml
@@ -61,12 +61,13 @@
             <h5 class="text-muted text-sm-center mb-3">Select the user's role assignments:</h5>
             <hr />
             <div class="mx-auto">
-                <table class="table table-sm w-100" data-order='[[1,"asc"]]'>
+                <table class="table table-sm w-100" data-order='[[2,"asc"]]'>
                     <thead>
                         <tr>
                             <th class="col-auto" id="thSelect" data-orderable="false">
                                 <label asp-for="UserModel.Roles.ElementAt(0).IsAssigned"></label>
                             </th>
+                            <th><label asp-for="UserModel.Roles.ElementAt(0).Id"></label></th>
                             <th><label asp-for="UserModel.Roles.ElementAt(0).Name"></label></th>
                             <th><label asp-for="UserModel.Roles.ElementAt(0).Description"></label></th>
                         </tr>
@@ -79,6 +80,9 @@
                                 <tr>
                                     <td class="align-middle">
                                         <input class="form-check ms-3" type="checkbox" @checkedVal />
+                                    </td>
+                                    <td>
+                                        @Html.DisplayFor(x => role.Id)
                                     </td>
                                     <td>
                                         @Html.DisplayFor(x => role.Name)
@@ -105,7 +109,15 @@
 @section Scripts {
 
     <script defer>
-        var dt = $('table').DataTable();
+        var dt = $('table').DataTable({
+            columnDefs: [
+                {
+                    target: 1,
+                    visible: false,
+                    searchable: false
+                }
+            ]
+        });
 
         $("#btnCreate").click(function (event) {
             var roles = [];

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml
@@ -75,12 +75,13 @@
             <h5 class="text-muted text-sm-center mb-3">Select the user's role assignments:</h5>
             <hr />
             <div class="mx-auto">
-                <table class="table table-sm w-100" data-order='[[1,"asc"]]'>
+                <table class="table table-sm w-100" data-order='[[2,"asc"]]'>
                     <thead>
                         <tr>
                             <th id="thSelect" class="col-auto" data-orderable="false">
                                 <label asp-for="UserModel.Roles.ElementAt(0).IsAssigned"></label>
                             </th>
+                            <th><label asp-for="UserModel.Roles.ElementAt(0).Id"></label></th>
                             <th><label asp-for="UserModel.Roles.ElementAt(0).Name"></label></th>
                             <th><label asp-for="UserModel.Roles.ElementAt(0).Description"></label></th>
                         </tr>
@@ -93,6 +94,9 @@
                                 <tr>
                                     <td class="align-middle">
                                         <input class="form-check ms-3" type="checkbox" @checkedVal @checkboxDisabled />
+                                    </td>
+                                    <td>
+                                        @Html.DisplayFor(x => role.Id)
                                     </td>
                                     <td>
                                         @Html.DisplayFor(x => role.Name)
@@ -119,7 +123,15 @@
 @section Scripts {
 
     <script defer>
-        var dt = $('table').DataTable();
+        var dt = $('table').DataTable({
+            columnDefs: [
+                {
+                    target: 1,
+                    visible: false,
+                    searchable: false
+                }
+            ]
+        });
 
         $("#btnSave").click(function (event) {
             var roles = [];

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
@@ -25,10 +25,10 @@ public abstract class IndexModel : ModelBase
                 {
                     if (_basePath is null)
                     {
-                        var path = Request.Path.Value;
+                        var path = Request.Path.Value.AsSpan();
                         _basePath = (
                             path.EndsWith(IndexHandler.PageName) ? path[..(path.Length - IndexHandler.PageName.Length)] : path
-                            ).TrimEnd('/');
+                            ).TrimEnd('/').ToString();
                     }
                 }
             }

--- a/Authorization.Core/AuthorizationManager.cs
+++ b/Authorization.Core/AuthorizationManager.cs
@@ -388,7 +388,7 @@ namespace CRFricke.Authorization.Core
 
                 hashSet = (await (
                     from uc in dbContext.Set<IdentityUserClaim<string>>()
-                    join ar in dbContext.Set<TRole>() on uc.ClaimValue equals ar.Name
+                    join ar in dbContext.Set<TRole>() on uc.ClaimValue equals ar.Id
                     where uc.UserId == userId && uc.ClaimType == ClaimTypes.Role
                     select ar.Id
                     ).ToArrayAsync()).ToHashSet();


### PR DESCRIPTION
IdentityUserClaim objects contain the names of the AppRole entities assigned to an AppUser. If an AppRole is renamed, the associated IdentityUserClaims are orphaned because they are not updated with the new name.

We now store the Id of the AppRole in the `ClaimValue` property of the IdentityUserClaim.