### PR TITLE
Use global.json to restrict build tasks to .net8.0 SDK.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,9 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
-          9.0.x
+        dotnet-version: 8.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
-          9.0.x
+        dotnet-version: 8.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:
@@ -55,7 +53,7 @@ jobs:
       run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal
 
     - name: Create NuGet packages
-      run: dotnet pack Authorization.Core.NoTests.slnf --configuration $BUILD_CONFIG --no-build /p:Version=$BUILD_VERSION -p:TargetFrameworks=net8.0
+      run: dotnet pack Authorization.Core.NoTests.slnf --configuration $BUILD_CONFIG --no-build /p:Version=$BUILD_VERSION
 
     - name: Upload packages to NuGet.org
       run: dotnet nuget push "**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -32,9 +32,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.x
-          9.0.x
+        dotnet-version: 8.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:
@@ -54,7 +52,7 @@ jobs:
       run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal
 
     - name: Create NuGet packages
-      run: dotnet pack Authorization.Core.NoTests.slnf --configuration $BUILD_CONFIG --no-build /p:Version=$BUILD_VERSION -p:TargetFrameworks=net8.0
+      run: dotnet pack Authorization.Core.NoTests.slnf --configuration $BUILD_CONFIG --no-build /p:Version=$BUILD_VERSION
 
     - name: Upload NuGet packages to GitHub
       run: dotnet nuget push "**/*.nupkg" --source https://nuget.pkg.github.com/CRFricke/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/Authorization.Core.UI/Authorization.Core.UI.csproj
+++ b/Authorization.Core.UI/Authorization.Core.UI.csproj
@@ -62,8 +62,10 @@
   
   <!-- The remainder of this project file generates the build files required to pack the static web assets for the NuGet package. -->
   <!-- Based on Microsoft.AspNetCore.Identity.UI project file located at: --> 
-  <!--   https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj --> 
-  <PropertyGroup>
+  <!--   https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj -->
+
+	<PropertyGroup>
+	<EnableDefaultRazorGenerateItems>false</EnableDefaultRazorGenerateItems>
     <ProvideApplicationPartFactoryAttributeTypeName>Microsoft.AspNetCore.Mvc.ApplicationParts.NullApplicationPartFactory, Microsoft.AspNetCore.Mvc.Core</ProvideApplicationPartFactoryAttributeTypeName>
     <DisableStaticWebAssetsBuildPropsFileGeneration>true</DisableStaticWebAssetsBuildPropsFileGeneration>
     <StaticWebAssetsDisableProjectBuildPropsFileGeneration>true</StaticWebAssetsDisableProjectBuildPropsFileGeneration>
@@ -73,13 +75,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Remove="assets\BS5\lib\bootstrap\font\bootstrap-icons.json" />
-    <Content Remove="libman.json" />
-    <Content Update="**\*.cshtml" Pack="false" />
+    <None Include="@(Content)" />
+    <Content Remove="@(Content)" />
     <None Include="build\*" Pack="true" PackagePath="build\" />
     <None Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" />
     <None Include="buildTransitive\*" Pack="true" PackagePath="buildTransitive\" />
   </ItemGroup>
+
+  <Target Name="SetupRazorInputs" BeforeTargets="ResolveRazorGenerateInputs">
+    <ItemGroup>
+      <_RazorGenerate Include="Areas\Authorization\Pages\**\*.cshtml" />
+
+      <RazorGenerate Include="@(_RazorGenerate)" Link="Areas\Authorization\Pages\%(RecursiveDir)%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="GetAuthUIAssets" Returns="@(ReferenceAsset)">
     <PropertyGroup>
@@ -96,7 +105,14 @@
       </ReferenceAssetCandidates>
     </ItemGroup>
     
-    <DefineStaticWebAssets Condition="'@(ReferenceAssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(ReferenceAssetCandidates)" SourceId="$(PackageId)" SourceType="Project" AssetKind="All" BasePath="$(StaticWebAssetBasePath)">
+    <DefineStaticWebAssets 
+	  Condition="'@(ReferenceAssetCandidates->Count())' != '0'" 
+	  CandidateAssets="@(ReferenceAssetCandidates)" 
+	  SourceId="$(PackageId)" 
+	  SourceType="Project" 
+	  AssetKind="All" 
+	  BasePath="$(StaticWebAssetBasePath)"
+	  >
       <Output TaskParameter="Assets" ItemName="ReferenceAsset" />
     </DefineStaticWebAssets>
     <ItemGroup>
@@ -107,6 +123,9 @@
   </Target>
 
   <Target Name="_GenerateAuthUIPackItems" BeforeTargets="GenerateStaticWebAssetsPackFiles">
+
+	<Message Importance="High" Text="StaticWebAssetsSdkBuildTasksAssembly: $(StaticWebAssetsSdkBuildTasksAssembly)" />
+
     <ItemGroup>
       <BS4AssetCandidates Include="assets\BS4\**" />
       <BS4AssetCandidates>
@@ -119,16 +138,40 @@
       </BS5AssetCandidates>
     </ItemGroup>
     
-    <DefineStaticWebAssets Condition="'@(BS4AssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(BS4AssetCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/BS4" BasePath="$(StaticWebAssetBasePath)">
+    <DefineStaticWebAssets 
+	  Condition="'@(BS4AssetCandidates->Count())' != '0'" 
+	  CandidateAssets="@(BS4AssetCandidates)" 
+	  SourceId="$(PackageId)" 
+	  SourceType="Discovered" 
+	  AssetKind="All" 
+	  ContentRoot="assets/BS4" 
+	  BasePath="$(StaticWebAssetBasePath)"
+	  >
       <Output TaskParameter="Assets" ItemName="BS4Assets" />
     </DefineStaticWebAssets>
     
-    <DefineStaticWebAssets Condition="'@(BS5AssetCandidates-&gt;Count())' != '0'" CandidateAssets="@(BS5AssetCandidates)" SourceId="$(PackageId)" SourceType="Discovered" AssetKind="All" ContentRoot="assets/BS5" BasePath="$(StaticWebAssetBasePath)">
+    <DefineStaticWebAssets 
+	  Condition="'@(BS5AssetCandidates->Count())' != '0'" 
+	  CandidateAssets="@(BS5AssetCandidates)" 
+	  SourceId="$(PackageId)" 
+	  SourceType="Discovered" 
+	  AssetKind="All" 
+	  ContentRoot="assets/BS5" 
+	  BasePath="$(StaticWebAssetBasePath)"
+	  >
       <Output TaskParameter="Assets" ItemName="BS5Assets" />
     </DefineStaticWebAssets>
 
-    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(BS4Assets)" PackagePathPrefix="staticwebassets/BS4" TargetPropsFilePath="$(IntermediateOutputPath)AuthUI.BS4.targets" />
-    <GenerateStaticWebAssetsPropsFile StaticWebAssets="@(BS5Assets)" PackagePathPrefix="staticwebassets/BS5" TargetPropsFilePath="$(IntermediateOutputPath)AuthUI.BS5.targets" />
+    <GenerateStaticWebAsssetsPropsFile 
+	  StaticWebAssets="@(BS4Assets)" 
+	  PackagePathPrefix="staticwebassets/BS4" 
+	  TargetPropsFilePath="$(IntermediateOutputPath)AuthUI.BS4.targets" 
+	  />
+    <GenerateStaticWebAsssetsPropsFile 
+	  StaticWebAssets="@(BS5Assets)" 
+	  PackagePathPrefix="staticwebassets/BS5" 
+	  TargetPropsFilePath="$(IntermediateOutputPath)AuthUI.BS5.targets" 
+	  />
 
     <ComputeStaticWebAssetsTargetPaths Assets="@(BS4Assets)" PathPrefix="staticwebassets/BS4" AdjustPathsForPack="true">
       <Output TaskParameter="AssetsWithTargetPath" ItemName="_PackStaticWebAssetWithTargetPath" />

--- a/Authorization.Core.sln
+++ b/Authorization.Core.sln
@@ -7,6 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Authorization.Core", "Autho
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F6AEEA8D-84AB-48C4-8F2B-CD140ECCFB1D}"
 	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
This pull request updates the .NET version across multiple YAML files and enhances the project configuration for Razor generation and static web assets. Key changes include:
- `dotnet.yml`, `release.yml`, `tag.yml`: Updated to specify only `.NET 8.0.x` and added NuGet source configuration.
- `release.yml`, `tag.yml`: Removed `-p:TargetFrameworks=net8.0` from the `dotnet pack` command.
- `Authorization.Core.UI.csproj`: Added properties and targets for Razor generation and asset management.
- `Authorization.Core.sln`: Updated to reflect a new minimum Visual Studio version.
- Added `global.json` to specify the SDK version and roll-forward behavior.
