### PR TITLE
Migrate tests to Microsoft Testing Platform and enhance CI/CD workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -75,7 +75,7 @@ jobs:
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
         filename: 'CodeCoverage/Cobertura.xml'
-        badge: false
+        badge: true
         fail_below_min: true
         format: markdown
         hide_branch_rate: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,15 +5,24 @@ on:
     branches: [ '**' ]
     paths-ignore: ['**/*.md']
 
-jobs:
-  build:
+  pull_request:
+    branches: [ master ]
 
-    env:
-      BUILD_CONFIG: 'Release'
+env:
+  BUILD_CONFIG: 'Release'
+
+jobs:
+
+  build:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      contents: read
+
     steps:
+
     - name: Setup PowerShell
       uses: CRFricke/Setup-PowerShell@v1.0.10
 
@@ -50,4 +59,47 @@ jobs:
       run: ./Authorization.Core.UI.Tests.Integration/bin/Release/net10.0/playwright.ps1 install
 
     - name: Test
-      run: dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal
+      run: |
+        dotnet test --configuration $BUILD_CONFIG --no-build --verbosity normal \
+          --coverlet --coverlet-output-format cobertura \
+          --coverlet-include '[CRFricke.Authorization.Core]*' \
+          --coverlet-include '[CRFricke.Authorization.Core.UI]*' 
+
+    - name: Merge Coverage Data
+      run: |
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        reportgenerator -reports:**/TestResults/coverage.cobertura.xml -targetdir:CodeCoverage \
+          -reporttypes:'Cobertura' 
+
+    - name: Generate Code Coverage Summary
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: 'CodeCoverage/Cobertura.xml'
+        badge: false
+        fail_below_min: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both
+        thresholds: '50 75'
+
+    - name: Run security scan
+      shell: pwsh
+      run: |
+        $filePath = "SecurityScan.log"
+        $searchText = "has the following vulnerable packages"
+        dotnet list package --no-restore --vulnerable --include-transitive > $filePath
+        $matches = Select-String -Path $filePath -Pattern $searchText
+        if ($matches) {
+           cat $filePath
+           Write-ActionWarning "Vulnerable packages detected."
+        }
+
+    - name: Add Coverage PR Comment
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        recreate: true
+        path: code-coverage-results.md

--- a/Authorization.Core.Tests/Authorization.Core.Tests.csproj
+++ b/Authorization.Core.Tests/Authorization.Core.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
-	<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,22 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-	<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+	<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageReference Include="MockQueryable.Moq" Version="10.0.5" />
-	<PackageReference Include="xunit.v3" Version="3.2.2" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-		  <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+	<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Authorization.Core.Tests/xunit.runner.json
+++ b/Authorization.Core.Tests/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}

--- a/Authorization.Core.UI.Tests.Integration/Authorization.Core.UI.Tests.Integration.csproj
+++ b/Authorization.Core.UI.Tests.Integration/Authorization.Core.UI.Tests.Integration.csproj
@@ -6,35 +6,20 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
-	<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Usings.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
-	<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.58.0" />
+	<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-	  <PackageReference Include="xunit.v3" Version="3.2.2" />
-	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
+	<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Authorization.Core.UI.Tests.Integration/Usings.cs
+++ b/Authorization.Core.UI.Tests.Integration/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/Authorization.Core.UI.Tests.Integration/xunit.runner.json
+++ b/Authorization.Core.UI.Tests.Integration/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}

--- a/Authorization.Core.UI.Tests.Playwright/Authorization.Core.UI.Tests.Playwright.csproj
+++ b/Authorization.Core.UI.Tests.Playwright/Authorization.Core.UI.Tests.Playwright.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
-	<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,21 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-	<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
+	<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
+	<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Authorization.Core.UI.Tests.Playwright/xunit.runner.json
+++ b/Authorization.Core.UI.Tests.Playwright/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}

--- a/Authorization.Core.UI.Tests/Authorization.Core.UI.Tests.csproj
+++ b/Authorization.Core.UI.Tests/Authorization.Core.UI.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
-	<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,25 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-	<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" Version="8.0.1" />
     <PackageReference Include="CRFricke.Test.Support" Version="10.0.0-beta1.0" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.5" />
+	<PackageReference Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageReference Include="MockQueryable.Moq" Version="10.0.5" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-	<PackageReference Include="xunit.v3" Version="3.2.2" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+	<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Authorization.Core.UI.Tests/xunit.runner.json
+++ b/Authorization.Core.UI.Tests/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![Authorization.Core](https://raw.githubusercontent.com/CRFricke/Authorization.Core/master/icon.png)
 
-[![.NET](https://github.com/CRFricke/Authorization.Core/actions/workflows/dotnet.yml/badge.svg)](https://github.com/CRFricke/Authorization.Core/actions/workflows/dotnet.yml) 
-[![Tag](https://github.com/CRFricke/Authorization.Core/actions/workflows/tag.yml/badge.svg)](https://github.com/CRFricke/Authorization.Core/actions/workflows/tag.yml)
-[![Release](https://github.com/CRFricke/Authorization.Core/actions/workflows/release.yml/badge.svg)](https://github.com/CRFricke/Authorization.Core/actions/workflows/release.yml)
+[![CI/CD](https://github.com/CRFricke/Authorization.Core/actions/workflows/dotnet.yml/badge.svg)](https://github.com/CRFricke/Authorization.Core/actions/workflows/dotnet.yml) 
+![.NET](https://img.shields.io/badge/.NET-10.0-purple)
 # Authorization.Core
 
 The Authorization.Core package provides an efficient implementation of a rights-based authorization 

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "9.0.100",
     "rollForward": "latestMajor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
This pull request updates the testing infrastructure to use the new Microsoft Testing Platform (MTP) and improves the CI workflow for .NET projects. The main changes include migrating test projects to use MTP, updating coverage and reporting tools, and enhancing the GitHub Actions workflow with new steps for coverage reporting and security scanning.

**Migration to Microsoft Testing Platform and test infrastructure updates:**

* All test project files (`*.csproj`) now use `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` instead of the legacy `TestingPlatformDotnetTestSupport`, and reference `Microsoft.Testing.Platform` and `xunit.v3.mtp-v2` instead of older test SDKs and runners. The `coverlet.MTP` package replaces `coverlet.collector` for coverage. (`[[1]](diffhunk://#diff-db5eb64e2a9b8f9aa5fcfc8e8a41f0c5bdb015ee1c58d3f3f2cc7055b53c099fL9-R21)`, `[[2]](diffhunk://#diff-7de9e1df0273e5974ba05c8400ca5f319f584600b428c299ed8fec197a9ad40aL9-R22)`, `[[3]](diffhunk://#diff-73edcbcf6200c6d42d53cd3a1baef671b12792f3fcdc47438bb743e4d2a6eb1eL8-R19)`, `[[4]](diffhunk://#diff-e6eaa32751b7b5f07ac651339ba2d428e7d9cd749d3c93cd90fa81d2b41b924eL9-R23)`)
* Removed `xunit.runner.json` files from all test projects, as MTP and the new runner package no longer require them. (`[[1]](diffhunk://#diff-adeeea83e10df3829a21e11c8ce832579b63217dc71741e133fa33a8f919964fL1-L3)`, `[[2]](diffhunk://#diff-adeeea83e10df3829a21e11c8ce832579b63217dc71741e133fa33a8f919964fL1-L3)`, `[[3]](diffhunk://#diff-adeeea83e10df3829a21e11c8ce832579b63217dc71741e133fa33a8f919964fL1-L3)`, `[[4]](diffhunk://#diff-adeeea83e10df3829a21e11c8ce832579b63217dc71741e133fa33a8f919964fL1-L3)`, `[[5]](diffhunk://#diff-c59ac217e20714986961b9ad967420a323412386192ec31d73c518db45d4d5ddL1)`)

**CI/CD workflow improvements:**

* The `.github/workflows/dotnet.yml` workflow is restructured to use the `pull_request` trigger for `master` and to request appropriate permissions for pull request comments. (`[.github/workflows/dotnet.ymlL8-R25](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L8-R25)`)
* The build job now runs tests with the new MTP-compatible coverage collector, merges coverage data, generates a markdown summary, and posts it as a sticky pull request comment. (`[.github/workflows/dotnet.ymlL53-R105](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L53-R105)`)
* Added a security scan step to the workflow to check for vulnerable packages and issue warnings if any are found. (`[.github/workflows/dotnet.ymlL53-R105](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L53-R105)`)

**Documentation and configuration updates:**

* The `README.md` badge section is updated to clarify CI/CD and .NET version support. (`[README.mdL3-R4](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R4)`)
* `global.json` is updated to specify `Microsoft.Testing.Platform` as the test runner. (`[global.jsonR5-R7](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfR5-R7)`)