### PR TITLE
Centralize workflow config with global env variables

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,7 @@ name: .NET
 on:
   push:
     branches: [ '**' ]
-    paths-ignore: ['**/*.md']
+    paths-ignore: ['**/*.md', '**/tag.yml', '**/release.yml']
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   release:
     types: [published]
 
+env:
+  BUILD_CONFIG: 'Release'
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  TAG_PREFIX: 'v10'
+
 jobs:
   build:
-
-    env:
-      BUILD_CONFIG: 'Release'
 
     runs-on: ubuntu-latest
 
@@ -23,7 +27,7 @@ jobs:
       shell: pwsh
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: 'v10'
+          TAG_PREFIX: ${{ env.TAG_PREFIX }}
       run: |
         Get-VersionVariables
         if ($Tag_PreRelease -or $Tag_Build) { throw "Invalid GITHUB_REF for release." }
@@ -33,7 +37,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: ${{ env.DOTNET_VERSION }}
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,11 +4,15 @@ on:
   push:
     tags: ['v*']
 
+env:
+  BUILD_CONFIG: 'Release'
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  TAG_PREFIX: 'v10'
+
 jobs:
   build:
-
-    env:
-      BUILD_CONFIG: 'Release'
 
     runs-on: ubuntu-latest
 
@@ -23,7 +27,7 @@ jobs:
       shell: pwsh
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: 'v10'
+          TAG_PREFIX: ${{ env.TAG_PREFIX }}
       run: |
         Get-VersionVariables
         Set-ActionVariable "BUILD_VERSION" "$Tag_Version"
@@ -32,7 +36,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: ${{ env.DOTNET_VERSION }}
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:


### PR DESCRIPTION
Added global env variables to release.yml and tag.yml for easier .NET version and config management. Updated dotnet.yml to ignore workflow file changes on push. Replaced hardcoded TAG_PREFIX and DOTNET_VERSION with env references for better maintainability.