### PR TITLE
Centralize build configuration and modernize codebase for C# 9+

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@
 
 # CA1034: Nested types should not be visible
 dotnet_diagnostic.CA1034.severity = suggestion
+
+# CA1873: Avoid potentially expensive logging
+dotnet_diagnostic.CA1873.severity = silent

--- a/Authorization.Core.Tests/Authorization.Core.Tests.csproj
+++ b/Authorization.Core.Tests/Authorization.Core.Tests.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+	<IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
 	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/Authorization.Core.Tests/AuthorizationManagerTests.cs
+++ b/Authorization.Core.Tests/AuthorizationManagerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using MockQueryable.Moq;
 using Moq;
+using System.Globalization;
 using System.Security.Claims;
 
 using AuthorizationFailure = CRFricke.Authorization.Core.AuthorizationFailure;
@@ -24,7 +25,7 @@ public class AuthorizationManagerTests
     private static readonly Claim[] emptyClaims = [];
 
     [Fact(DisplayName = "AuthorizeAsync returns NoUserId")]
-    public async Task AuthorizationManagerTest01Async()
+    public async Task Test01Async()
     {
         var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -40,11 +41,11 @@ public class AuthorizationManagerTests
 
         Assert.False(result.Succeeded);
         Assert.Equal(AuthorizationFailure.Reason.NoUserId, result.Failure!.FailureReason);
-        Assert.Equal(appClaimRequirement.ClaimValues, result.Failure.FailingClaims);
+        Assert.Equal(appClaimRequirement.ClaimValues.Order(), result.Failure.FailingClaims!.Order());
     }
 
     [Fact(DisplayName = "AuthorizeAsync returns NotAuthorized")]
-    public async Task AuthorizationManagerTest02Async()
+    public async Task Test02Async()
     {
         var user = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole() { Name = "RoleManager" };
@@ -81,11 +82,11 @@ public class AuthorizationManagerTests
 
         Assert.False(result.Succeeded);
         Assert.Equal(AuthorizationFailure.Reason.NotAuthorized, result.Failure!.FailureReason);
-        Assert.Equal(appClaimRequirement.ClaimValues, result.Failure!.FailingClaims);
+        Assert.Equal(appClaimRequirement.ClaimValues.Order(), result.Failure!.FailingClaims!.Order());
     }
 
     [Fact(DisplayName = "AuthorizeAsync returns Succeeded for Administrator")]
-    public async Task AuthorizationManagerTest03Async()
+    public async Task Test03Async()
     {
         var user = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole() { Name = "Administrator" };
@@ -117,7 +118,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync returns Succeeded")]
-    public async Task AuthorizationManagerTest04Async()
+    public async Task Test04Async()
     {
         var user = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole() { Name = "RoleManager" };
@@ -157,7 +158,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync loads UserRoleCache")]
-    public async Task AuthorizationManagerTest05Async()
+    public async Task Test05Async()
     {
         var user = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole() { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
@@ -201,7 +202,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync returns ArgumentException")]
-    public async Task AuthorizationManagerTest07Async()
+    public async Task Test07Async()
     {
         var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -214,16 +215,16 @@ public class AuthorizationManagerTests
 
         var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
         var ex = await Record.ExceptionAsync(async () =>
-            await authorizationManager.AuthorizeAsync(claimsPrincipal, Guid.Empty.ToString(), appClaimRequirement)
+            await authorizationManager.AuthorizeAsync(claimsPrincipal, Guid.Empty.ToString(), appClaimRequirement).ConfigureAwait(false)
             );
 
         Assert.NotNull(ex);
         Assert.IsType<ArgumentException>(ex);
-        Assert.Contains($"does not implement {nameof(IRequiresAuthorization)} interface", ex.Message);
+        Assert.Contains($"does not implement {nameof(IRequiresAuthorization)} interface", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "RefreshUser removes UserRoleCache entry")]
-    public void AuthorizationManagerTest08()
+    public void Test08()
     {
         object? cacheKey = null;
         var user = new AppUser("TestUser@StEmilian.com");
@@ -245,7 +246,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "RefreshRole removes RoleClaimCache entry")]
-    public void AuthorizationManagerTest09()
+    public void Test09()
     {
         object? cacheKey = null;
         var role = new AppRole() { Name = "RoleManager" };
@@ -267,7 +268,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded for Administrator")]
-    public async Task AuthorizationManagerTest10Async()
+    public async Task Test10Async()
     {
         var user = new AppUser("TestUser@StEmilian.com");
         var newUser = new AppUser("NewUser@StEmilian.com");
@@ -299,7 +300,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation for adding Administrator role")]
-    public async Task AuthorizationManagerTest11Async()
+    public async Task Test11Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
@@ -352,11 +353,11 @@ public class AuthorizationManagerTests
 
         Assert.False(result.Succeeded);
         Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-        Assert.Equal(expectedClaims, result.Failure!.FailingClaims);
+        Assert.Equal(expectedClaims.Order(), result.Failure!.FailingClaims!.Order());
     }
 
     [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation")]
-    public async Task AuthorizationManagerTest12Async()
+    public async Task Test12Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
@@ -411,11 +412,11 @@ public class AuthorizationManagerTests
 
         Assert.False(result.Succeeded);
         Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-        Assert.Equal(expectedClaims, result.Failure.FailingClaims);
+        Assert.Equal(expectedClaims.Order(), result.Failure.FailingClaims!.Order());
     }
 
     [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded")]
-    public async Task AuthorizationManagerTest13Async()
+    public async Task Test13Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
@@ -471,7 +472,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded for Administrator")]
-    public async Task AuthorizationManagerTest14Async()
+    public async Task Test14Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var role = new AppRole { Name = "NewRole" };
@@ -503,7 +504,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AuthorizeAsync [Role] returns Elevation")]
-    public async Task AuthorizationManagerTest15Async()
+    public async Task Test15Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
@@ -554,11 +555,11 @@ public class AuthorizationManagerTests
 
         Assert.False(result.Succeeded);
         Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-        Assert.Equal(expectedClaims, result.Failure.FailingClaims);
+        Assert.Equal(expectedClaims.Order(), result.Failure.FailingClaims!.Order());
     }
 
     [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded")]
-    public async Task AuthorizationManagerTest16Async()
+    public async Task Test16Async()
     {
         var principal = new AppUser("TestUser@StEmilian.com");
         var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
@@ -610,7 +611,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "IsAuthorized returns True")]
-    public async Task AuthorizationManagerTest17Async()
+    public async Task Test17Async()
     {
         var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
         var roleClaimCache = new Mock<RoleClaimCache>();
@@ -647,7 +648,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "IsAuthorized returns False")]
-    public async Task AuthorizationManagerTest18Async()
+    public async Task Test18Async()
     {
         var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
         var roleClaimCache = new Mock<RoleClaimCache>();
@@ -684,7 +685,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AppClaimRequirementProvider returns valid AuthorizationPolicy")]
-    public async Task AuthorizationManagerTest19Async()
+    public async Task Test19Async()
     {
         var attribute = new RequiresClaimsAttribute(SysClaims.Role.Read);
 
@@ -700,7 +701,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [User] fails delete request for system user")]
-    public async Task AuthorizationManagerTest20Async()
+    public async Task Test20Async()
     {
         var principal = new AppUser("UserManager@StEmilian.com");
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -732,15 +733,15 @@ public class AuthorizationManagerTests
         Assert.False(authContext.HasSucceeded);
         Assert.Equal(1,logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
-        Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
-        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(resource.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [User] fails claim update request for system user")]
-    public async Task AuthorizationManagerTest21Async()
+    public async Task Test21Async()
     {
         var principal = new AppUser("UserManager@StEmilian.com");
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -772,15 +773,15 @@ public class AuthorizationManagerTests
         Assert.False(authContext.HasSucceeded);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
-        Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
-        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(resource.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [User] allows update request for non-system user")]
-    public async Task AuthorizationManagerTest22Async()
+    public async Task Test22Async()
     {
         var resource = new AppUser("ExistingUser@StEmilian.com");
         var principal = new AppUser("UserManager@StEmilian.com");
@@ -837,7 +838,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails delete request for system role")]
-    public async Task AuthorizationManagerTest23Async()
+    public async Task Test23Async()
     {
         var principal = new AppUser("UserManager@StEmilian.com");
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -869,15 +870,15 @@ public class AuthorizationManagerTests
         Assert.False(authContext.HasSucceeded);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
-        Assert.Contains(resource.Name, logger.LatestRecord.Message);
-        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(resource.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails claim update request for system role")]
-    public async Task AuthorizationManagerTest24Async()
+    public async Task Test24Async()
     {
         var principal = new AppUser("UserManager@StEmilian.com");
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -909,15 +910,15 @@ public class AuthorizationManagerTests
         Assert.False(authContext.HasSucceeded);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
-        Assert.Contains(resource.Name, logger.LatestRecord.Message);
-        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(resource.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [Role] allows update request for non-system role")]
-    public async Task AuthorizationManagerTest25Async()
+    public async Task Test25Async()
     {
         var resource = new AppRole() { Name = "ExistingRole" };
         var principal = new AppUser("RoleManager@StEmilian.com");
@@ -964,7 +965,7 @@ public class AuthorizationManagerTests
     }
 
     [Fact(DisplayName = "AppClaimRequirementHandler [Role] only returns failing claims.")]
-    public async Task AuthorizationManagerTest26Async()
+    public async Task Test26Async()
     {
         var principal = new AppUser("RoleManager@StEmilian.com");
         var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
@@ -1004,6 +1005,6 @@ public class AuthorizationManagerTests
         Assert.False(authContext.HasSucceeded);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.DoesNotContain(SysClaims.Role.Read, logger.LatestRecord.Message);
+        Assert.DoesNotContain(SysClaims.Role.Read, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 }

--- a/Authorization.Core.Tests/AuthorizationManagerTests.cs
+++ b/Authorization.Core.Tests/AuthorizationManagerTests.cs
@@ -15,996 +15,995 @@ using System.Security.Claims;
 
 using AuthorizationFailure = CRFricke.Authorization.Core.AuthorizationFailure;
 
-namespace Authorization.Core.Tests
+namespace Authorization.Core.Tests;
+
+delegate void TryGetValueDelegate(object key, out object value);
+
+public class AuthorizationManagerTests
 {
-    delegate void TryGetValueDelegate(object key, out object value);
+    private static readonly Claim[] emptyClaims = [];
 
-    public class AuthorizationManagerTests
+    [Fact(DisplayName = "AuthorizeAsync returns NoUserId")]
+    public async Task AuthorizationManagerTest01Async()
     {
-        private static readonly Claim[] emptyClaims = [];
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == emptyClaims &&
+            cp.Identity!.Name == "TestUser@StEmilian.com"
+            );
 
-        [Fact(DisplayName = "AuthorizeAsync returns NoUserId")]
-        public async Task AuthorizationManagerTest01Async()
-        {
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == emptyClaims &&
-                cp.Identity!.Name == "TestUser@StEmilian.com"
-                );
+        var logger = new FakeLogger<AuthorizationManager>();
+        var serviceProvider = Mock.Of<IServiceProvider>();
 
-            var logger = new FakeLogger<AuthorizationManager>();
-            var serviceProvider = Mock.Of<IServiceProvider>();
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
 
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
+        Assert.False(result.Succeeded);
+        Assert.Equal(AuthorizationFailure.Reason.NoUserId, result.Failure!.FailureReason);
+        Assert.Equal(appClaimRequirement.ClaimValues, result.Failure.FailingClaims);
+    }
 
-            Assert.False(result.Succeeded);
-            Assert.Equal(AuthorizationFailure.Reason.NoUserId, result.Failure!.FailureReason);
-            Assert.Equal(appClaimRequirement.ClaimValues, result.Failure.FailingClaims);
-        }
+    [Fact(DisplayName = "AuthorizeAsync returns NotAuthorized")]
+    public async Task AuthorizationManagerTest02Async()
+    {
+        var user = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole() { Name = "RoleManager" };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
 
-        [Fact(DisplayName = "AuthorizeAsync returns NotAuthorized")]
-        public async Task AuthorizationManagerTest02Async()
-        {
-            var user = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole() { Name = "RoleManager" };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
+            cp.Identity!.Name == user.UserName
+            );
 
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
-                cp.Identity!.Name == user.UserName
-                );
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([role.Id]); }
+                )
+            ).Returns(true);
 
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([role.Id]); }
-                    )
-                ).Returns(true);
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
 
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
+        var logger = new FakeLogger<AuthorizationManager>();
 
-            var logger = new FakeLogger<AuthorizationManager>();
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
 
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
 
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
+        Assert.False(result.Succeeded);
+        Assert.Equal(AuthorizationFailure.Reason.NotAuthorized, result.Failure!.FailureReason);
+        Assert.Equal(appClaimRequirement.ClaimValues, result.Failure!.FailingClaims);
+    }
 
-            Assert.False(result.Succeeded);
-            Assert.Equal(AuthorizationFailure.Reason.NotAuthorized, result.Failure!.FailureReason);
-            Assert.Equal(appClaimRequirement.ClaimValues, result.Failure!.FailingClaims);
-        }
+    [Fact(DisplayName = "AuthorizeAsync returns Succeeded for Administrator")]
+    public async Task AuthorizationManagerTest03Async()
+    {
+        var user = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole() { Name = "Administrator" };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
 
-        [Fact(DisplayName = "AuthorizeAsync returns Succeeded for Administrator")]
-        public async Task AuthorizationManagerTest03Async()
-        {
-            var user = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole() { Name = "Administrator" };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
+            cp.Identity!.Name == user.UserName
+            );
 
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
-                cp.Identity!.Name == user.UserName
-                );
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
+                )
+            ).Returns(true);
 
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync returns Succeeded")]
+    public async Task AuthorizationManagerTest04Async()
+    {
+        var user = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole() { Name = "RoleManager" };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
+            cp.Identity!.Name == user.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([role.Id]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync loads UserRoleCache")]
+    public async Task AuthorizationManagerTest05Async()
+    {
+        var user = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole() { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
+        var userClaim = new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Id };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
+            cp.Identity!.Name == user.UserName
+            );
+
+        var dbContext = Mock.Of<AppDbContext>(db =>
+            db.Set<IdentityUserClaim<string>>() == new[] { userClaim }.BuildMockDbSet().Object &&
+            db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
+            );
+
+        var userRoleCache = new UserRoleCache();
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IRepository<AppUser, AppRole>)) == dbContext &&
+            sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache
+            );
+
+        Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
+            .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+
+        var tryResult = userRoleCache.TryGetValue(user.Id, out HashSet<string>? hashset);
+        Assert.True(tryResult);
+        Assert.Single(hashset!);
+        Assert.Contains(role.Id, hashset!);
+
+        userRoleCache.Dispose();
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync returns ArgumentException")]
+    public async Task AuthorizationManagerTest07Async()
+    {
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == emptyClaims &&
+            cp.Identity!.Name == "TestUser@StEmilian.com"
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var serviceProvider = Mock.Of<IServiceProvider>();
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var ex = await Record.ExceptionAsync(async () =>
+            await authorizationManager.AuthorizeAsync(claimsPrincipal, Guid.Empty.ToString(), appClaimRequirement)
+            );
+
+        Assert.NotNull(ex);
+        Assert.IsType<ArgumentException>(ex);
+        Assert.Contains($"does not implement {nameof(IRequiresAuthorization)} interface", ex.Message);
+    }
+
+    [Fact(DisplayName = "RefreshUser removes UserRoleCache entry")]
+    public void AuthorizationManagerTest08()
+    {
+        object? cacheKey = null;
+        var user = new AppUser("TestUser@StEmilian.com");
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.Remove(user.Id))
+            .Callback((object key) => { cacheKey = key; });
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        authorizationManager.RefreshUser(user.Id);
+
+        Assert.Equal(user.Id, cacheKey);
+    }
+
+    [Fact(DisplayName = "RefreshRole removes RoleClaimCache entry")]
+    public void AuthorizationManagerTest09()
+    {
+        object? cacheKey = null;
+        var role = new AppRole() { Name = "RoleManager" };
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.Remove(role.Id))
+            .Callback((object key) => { cacheKey = key; });
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        authorizationManager.RefreshRole(role.Id);
+
+        Assert.Equal(role.Id, cacheKey);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded for Administrator")]
+    public async Task AuthorizationManagerTest10Async()
+    {
+        var user = new AppUser("TestUser@StEmilian.com");
+        var newUser = new AppUser("NewUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
                     (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
-                    )
-                ).Returns(true);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-            Assert.Null(result.Failure);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync returns Succeeded")]
-        public async Task AuthorizationManagerTest04Async()
-        {
-            var user = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole() { Name = "RoleManager" };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
-                cp.Identity!.Name == user.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([role.Id]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-            Assert.Null(result.Failure);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync loads UserRoleCache")]
-        public async Task AuthorizationManagerTest05Async()
-        {
-            var user = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole() { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
-            var userClaim = new IdentityUserClaim<string> { Id = 1, UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = role.Id };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
-                cp.Identity!.Name == user.UserName
-                );
-
-            var dbContext = Mock.Of<AppDbContext>(db =>
-                db.Set<IdentityUserClaim<string>>() == new[] { userClaim }.BuildMockDbSet().Object &&
-                db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
-                );
-
-            var userRoleCache = new UserRoleCache();
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IRepository<AppUser, AppRole>)) == dbContext &&
-                sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache
-                );
-
-            Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
-                .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-
-            var tryResult = userRoleCache.TryGetValue(user.Id, out HashSet<string>? hashset);
-            Assert.True(tryResult);
-            Assert.Single(hashset!);
-            Assert.Contains(role.Id, hashset!);
-
-            userRoleCache.Dispose();
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync returns ArgumentException")]
-        public async Task AuthorizationManagerTest07Async()
-        {
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read);
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == emptyClaims &&
-                cp.Identity!.Name == "TestUser@StEmilian.com"
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var serviceProvider = Mock.Of<IServiceProvider>();
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var ex = await Record.ExceptionAsync(async () =>
-                await authorizationManager.AuthorizeAsync(claimsPrincipal, Guid.Empty.ToString(), appClaimRequirement)
-                );
-
-            Assert.NotNull(ex);
-            Assert.IsType<ArgumentException>(ex);
-            Assert.Contains($"does not implement {nameof(IRequiresAuthorization)} interface", ex.Message);
-        }
-
-        [Fact(DisplayName = "RefreshUser removes UserRoleCache entry")]
-        public void AuthorizationManagerTest08()
-        {
-            object? cacheKey = null;
-            var user = new AppUser("TestUser@StEmilian.com");
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.Remove(user.Id))
-                .Callback((object key) => { cacheKey = key; });
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            authorizationManager.RefreshUser(user.Id);
-
-            Assert.Equal(user.Id, cacheKey);
-        }
-
-        [Fact(DisplayName = "RefreshRole removes RoleClaimCache entry")]
-        public void AuthorizationManagerTest09()
-        {
-            object? cacheKey = null;
-            var role = new AppRole() { Name = "RoleManager" };
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.Remove(role.Id))
-                .Callback((object key) => { cacheKey = key; });
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            authorizationManager.RefreshRole(role.Id);
-
-            Assert.Equal(role.Id, cacheKey);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded for Administrator")]
-        public async Task AuthorizationManagerTest10Async()
-        {
-            var user = new AppUser("TestUser@StEmilian.com");
-            var newUser = new AppUser("NewUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                        (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
-                cp.Identity!.Name == user.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, newUser, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation for adding Administrator role")]
-        public async Task AuthorizationManagerTest11Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
-            var user = new AppUser("NewUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
-            var expectedClaims = new[] { nameof(SysGuids.Role.Administrator) };
-
-            var dbContext = Mock.Of<AppDbContext>(db =>
-                db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
-                sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
-                .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
-
-            Assert.False(result.Succeeded);
-            Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-            Assert.Equal(expectedClaims, result.Failure!.FailingClaims);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation")]
-        public async Task AuthorizationManagerTest12Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
-            var user = new AppUser("NewUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
-            var expectedClaims = SysClaims.Role.DefinedClaims;
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager, TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
-                sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
-                .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
-
-            Assert.False(result.Succeeded);
-            Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-            Assert.Equal(expectedClaims, result.Failure.FailingClaims);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded")]
-        public async Task AuthorizationManagerTest13Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
-            var user = new AppUser("NewUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
-            var expectedClaims = SysClaims.Role.DefinedClaims;
-
-            var dbContext = Mock.Of<AppDbContext>(db =>
-                db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-            userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
-                sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
-                .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-            Assert.Null(result.Failure);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded for Administrator")]
-        public async Task AuthorizationManagerTest14Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var role = new AppRole { Name = "NewRole" };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [Role] returns Elevation")]
-        public async Task AuthorizationManagerTest15Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
-            var expectedClaims = new[] { SysClaims.User.Read };
-
-            var role = new AppRole { Name = "NewRole" };
-            role.Claims.Add(
-                new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.Read }
-                );
-            role.Claims.Add(
-                new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.User.Read }
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([SysClaims.Role.Read, SysClaims.User.Read]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
-
-            Assert.False(result.Succeeded);
-            Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
-            Assert.Equal(expectedClaims, result.Failure.FailingClaims);
-        }
-
-        [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded")]
-        public async Task AuthorizationManagerTest16Async()
-        {
-            var principal = new AppUser("TestUser@StEmilian.com");
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
-
-            var role = new AppRole { Name = "NewRole" };
-            role.Claims.Add(
-                new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.List }
-                );
-            role.Claims.Add(
-                new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.Read }
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([SysClaims.Role.List, SysClaims.Role.Read]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-            var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
-
-            Assert.True(result.Succeeded);
-        }
-
-        [Fact(DisplayName = "IsAuthorized returns True")]
-        public async Task AuthorizationManagerTest17Async()
-        {
-            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([role.Id]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var result = await new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger)
-                .IsAuthorizedAsync(claimsPrincipal, SysClaims.User.Read);
-
-            Assert.True(result);
-        }
-
-        [Fact(DisplayName = "IsAuthorized returns False")]
-        public async Task AuthorizationManagerTest18Async()
-        {
-            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([role.Id]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-
-            var result = await new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger)
-                .IsAuthorizedAsync(claimsPrincipal, SysClaims.Role.Read);
-
-            Assert.False(result);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementProvider returns valid AuthorizationPolicy")]
-        public async Task AuthorizationManagerTest19Async()
-        {
-            var attribute = new RequiresClaimsAttribute(SysClaims.Role.Read);
-
-            var provider = new AppClaimRequirementProvider(
-                new OptionsWrapper<AuthorizationOptions>(new AuthorizationOptions())
-                );
-
-            var result = await provider.GetPolicyAsync(attribute.Policy!);
-
-            Assert.NotNull(result);
-            Assert.Single(result.Requirements);
-            Assert.Equal(result.Requirements[0].ToString(), attribute.ClaimValues[0]);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [User] fails delete request for system user")]
-        public async Task AuthorizationManagerTest20Async()
-        {
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var resource = new AppUser("Administrator@StEmilian.com") { Id = SysGuids.User.Administrator };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Delete);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.False(authContext.HasSucceeded);
-            Assert.Equal(1,logger.Collector.Count);
-            Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-            Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-            Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
-            Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
-            Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-            Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [User] fails claim update request for system user")]
-        public async Task AuthorizationManagerTest21Async()
-        {
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var resource = new AppUser("Administrator@StEmilian.com") { Id = SysGuids.User.Administrator };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.UpdateClaims);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.False(authContext.HasSucceeded);
-            Assert.Equal(1, logger.Collector.Count);
-            Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-            Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-            Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
-            Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
-            Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-            Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [User] allows update request for non-system user")]
-        public async Task AuthorizationManagerTest22Async()
-        {
-            var resource = new AppUser("ExistingUser@StEmilian.com");
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-            userRoleCache.Setup(mc => mc.TryGetValue(resource.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
-            var dbContext = Mock.Of<AppDbContext>(db =>
-                db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
-                );
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
-                sp.GetService(typeof(IRepository<AppUser, AppRole>)) == dbContext &&
-                sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
-                .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Update);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.True(authContext.HasSucceeded);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails delete request for system role")]
-        public async Task AuthorizationManagerTest23Async()
-        {
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Delete);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.False(authContext.HasSucceeded);
-            Assert.Equal(1, logger.Collector.Count);
-            Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-            Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-            Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
-            Assert.Contains(resource.Name, logger.LatestRecord.Message);
-            Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-            Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails claim update request for system role")]
-        public async Task AuthorizationManagerTest24Async()
-        {
-            var principal = new AppUser("UserManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.UpdateClaims);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.False(authContext.HasSucceeded);
-            Assert.Equal(1, logger.Collector.Count);
-            Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-            Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
-            Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
-            Assert.Contains(resource.Name, logger.LatestRecord.Message);
-            Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-            Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [Role] allows update request for non-system role")]
-        public async Task AuthorizationManagerTest25Async()
-        {
-            var resource = new AppRole() { Name = "ExistingRole" };
-            var principal = new AppUser("RoleManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-            roleClaimCache.Setup(mc => mc.TryGetValue(resource.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Update);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.True(authContext.HasSucceeded);
-        }
-
-        [Fact(DisplayName = "AppClaimRequirementHandler [Role] only returns failing claims.")]
-        public async Task AuthorizationManagerTest26Async()
-        {
-            var principal = new AppUser("RoleManager@StEmilian.com");
-            var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
-                cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
-                cp.Identity!.Name == principal.UserName
-                );
-
-            var userRoleCache = new Mock<UserRoleCache>();
-            userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
-                    )
-                ).Returns(true);
-
-            var roleClaimCache = new Mock<RoleClaimCache>();
-            roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
-                .Callback(new TryGetValueDelegate(
-                    (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
-                    )
-                ).Returns(true);
-
-            var serviceProvider = Mock.Of<IServiceProvider>(sp =>
-                sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
-                sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
-                );
-
-            var logger = new FakeLogger<AuthorizationManager>();
-            var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
-
-            var resource = new AppRole() { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
-            var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read, SysClaims.Role.UpdateClaims);
-            var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
-
-            await new AppClaimRequirementHandler(authManager)
-                .HandleAsync(authContext);
-
-            Assert.False(authContext.HasSucceeded);
-            Assert.Equal(1, logger.Collector.Count);
-            Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-            Assert.DoesNotContain(SysClaims.Role.Read, logger.LatestRecord.Message);
-        }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, user.Id) } &&
+            cp.Identity!.Name == user.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, newUser, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation for adding Administrator role")]
+    public async Task AuthorizationManagerTest11Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole { Id = SysGuids.Role.Administrator, Name = nameof(SysGuids.Role.Administrator) };
+        var user = new AppUser("NewUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
+        var expectedClaims = new[] { nameof(SysGuids.Role.Administrator) };
+
+        var dbContext = Mock.Of<AppDbContext>(db =>
+            db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
+            sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
+            .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
+        Assert.Equal(expectedClaims, result.Failure!.FailingClaims);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [User] returns Elevation")]
+    public async Task AuthorizationManagerTest12Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
+        var user = new AppUser("NewUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
+        var expectedClaims = SysClaims.Role.DefinedClaims;
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager, TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
+            sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
+            .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
+        Assert.Equal(expectedClaims, result.Failure.FailingClaims);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [User] returns Succeeded")]
+    public async Task AuthorizationManagerTest13Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
+        var user = new AppUser("NewUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Create);
+        var expectedClaims = SysClaims.Role.DefinedClaims;
+
+        var dbContext = Mock.Of<AppDbContext>(db =>
+            db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+        userRoleCache.Setup(mc => mc.TryGetValue(user.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
+            sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
+            .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, user, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded for Administrator")]
+    public async Task AuthorizationManagerTest14Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var role = new AppRole { Name = "NewRole" };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([SysGuids.Role.Administrator]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [Role] returns Elevation")]
+    public async Task AuthorizationManagerTest15Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+        var expectedClaims = new[] { SysClaims.User.Read };
+
+        var role = new AppRole { Name = "NewRole" };
+        role.Claims.Add(
+            new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.Read }
+            );
+        role.Claims.Add(
+            new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.User.Read }
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([SysClaims.Role.Read, SysClaims.User.Read]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(AuthorizationFailure.Reason.Elevation, result.Failure!.FailureReason);
+        Assert.Equal(expectedClaims, result.Failure.FailingClaims);
+    }
+
+    [Fact(DisplayName = "AuthorizeAsync [Role] returns Succeeded")]
+    public async Task AuthorizationManagerTest16Async()
+    {
+        var principal = new AppUser("TestUser@StEmilian.com");
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Create);
+
+        var role = new AppRole { Name = "NewRole" };
+        role.Claims.Add(
+            new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.List }
+            );
+        role.Claims.Add(
+            new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = SysClaims.Role.Read }
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([SysClaims.Role.List, SysClaims.Role.Read]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var authorizationManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+        var result = await authorizationManager.AuthorizeAsync(claimsPrincipal, role, appClaimRequirement);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact(DisplayName = "IsAuthorized returns True")]
+    public async Task AuthorizationManagerTest17Async()
+    {
+        var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([role.Id]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var result = await new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger)
+            .IsAuthorizedAsync(claimsPrincipal, SysClaims.User.Read);
+
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "IsAuthorized returns False")]
+    public async Task AuthorizationManagerTest18Async()
+    {
+        var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(role.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([role.Id]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+
+        var result = await new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger)
+            .IsAuthorizedAsync(claimsPrincipal, SysClaims.Role.Read);
+
+        Assert.False(result);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementProvider returns valid AuthorizationPolicy")]
+    public async Task AuthorizationManagerTest19Async()
+    {
+        var attribute = new RequiresClaimsAttribute(SysClaims.Role.Read);
+
+        var provider = new AppClaimRequirementProvider(
+            new OptionsWrapper<AuthorizationOptions>(new AuthorizationOptions())
+            );
+
+        var result = await provider.GetPolicyAsync(attribute.Policy!);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Requirements);
+        Assert.Equal(result.Requirements[0].ToString(), attribute.ClaimValues[0]);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [User] fails delete request for system user")]
+    public async Task AuthorizationManagerTest20Async()
+    {
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var resource = new AppUser("Administrator@StEmilian.com") { Id = SysGuids.User.Administrator };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Delete);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.False(authContext.HasSucceeded);
+        Assert.Equal(1,logger.Collector.Count);
+        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
+        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
+        Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [User] fails claim update request for system user")]
+    public async Task AuthorizationManagerTest21Async()
+    {
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var resource = new AppUser("Administrator@StEmilian.com") { Id = SysGuids.User.Administrator };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.UpdateClaims);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.False(authContext.HasSucceeded);
+        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
+        Assert.Contains(typeof(AppUser).Name, logger.LatestRecord.Message);
+        Assert.Contains(resource.UserName!, logger.LatestRecord.Message);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [User] allows update request for non-system user")]
+    public async Task AuthorizationManagerTest22Async()
+    {
+        var resource = new AppUser("ExistingUser@StEmilian.com");
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+        userRoleCache.Setup(mc => mc.TryGetValue(resource.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.UserManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.User.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var role = new AppRole { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
+        var dbContext = Mock.Of<AppDbContext>(db =>
+            db.Set<AppRole>() == new[] { role }.BuildMockDbSet().Object
+            );
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppUser>)) == new UserAuthorizationHandler<AppUser>() &&
+            sp.GetService(typeof(IRepository<AppUser, AppRole>)) == dbContext &&
+            sp.GetService(typeof(IHttpContextAccessor)) == new Mock<IHttpContextAccessor>().Object &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        Mock.Get(serviceProvider.GetRequiredService<IHttpContextAccessor>())
+            .Setup(hca => hca.HttpContext!.RequestServices).Returns(serviceProvider);
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.User.Update);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.True(authContext.HasSucceeded);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails delete request for system role")]
+    public async Task AuthorizationManagerTest23Async()
+    {
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Delete);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.False(authContext.HasSucceeded);
+        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
+        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
+        Assert.Contains(resource.Name, logger.LatestRecord.Message);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [Role] fails claim update request for system role")]
+    public async Task AuthorizationManagerTest24Async()
+    {
+        var principal = new AppUser("UserManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.UserManager]); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var resource = new AppRole() { Id = TestGuids.Role.RoleManager, Name = nameof(TestGuids.Role.RoleManager) };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.UpdateClaims);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.False(authContext.HasSucceeded);
+        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
+        Assert.Contains(appClaimRequirement.ToString(), logger.LatestRecord.Message);
+        Assert.Contains(typeof(AppRole).Name, logger.LatestRecord.Message);
+        Assert.Contains(resource.Name, logger.LatestRecord.Message);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
+        Assert.Contains("restricted operation on system", logger.LatestRecord.Message);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [Role] allows update request for non-system role")]
+    public async Task AuthorizationManagerTest25Async()
+    {
+        var resource = new AppRole() { Name = "ExistingRole" };
+        var principal = new AppUser("RoleManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+        roleClaimCache.Setup(mc => mc.TryGetValue(resource.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(IResourceAuthorizationHandler<AppRole>)) == new RoleAuthorizationHandler<AppRole>() &&
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Update);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.True(authContext.HasSucceeded);
+    }
+
+    [Fact(DisplayName = "AppClaimRequirementHandler [Role] only returns failing claims.")]
+    public async Task AuthorizationManagerTest26Async()
+    {
+        var principal = new AppUser("RoleManager@StEmilian.com");
+        var claimsPrincipal = Mock.Of<ClaimsPrincipal>(cp =>
+            cp.Claims == new[] { new Claim(ClaimTypes.NameIdentifier, principal.Id) } &&
+            cp.Identity!.Name == principal.UserName
+            );
+
+        var userRoleCache = new Mock<UserRoleCache>();
+        userRoleCache.Setup(mc => mc.TryGetValue(principal.Id, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>([TestGuids.Role.RoleManager]); }
+                )
+            ).Returns(true);
+
+        var roleClaimCache = new Mock<RoleClaimCache>();
+        roleClaimCache.Setup(mc => mc.TryGetValue(TestGuids.Role.RoleManager, out It.Ref<object>.IsAny!))
+            .Callback(new TryGetValueDelegate(
+                (key, out value) => { value = new HashSet<string>(SysClaims.Role.DefinedClaims); }
+                )
+            ).Returns(true);
+
+        var serviceProvider = Mock.Of<IServiceProvider>(sp =>
+            sp.GetService(typeof(UserRoleCache)) == userRoleCache.Object &&
+            sp.GetService(typeof(RoleClaimCache)) == roleClaimCache.Object
+            );
+
+        var logger = new FakeLogger<AuthorizationManager>();
+        var authManager = new AuthorizationManager<AppUser, AppRole>(serviceProvider, logger);
+
+        var resource = new AppRole() { Id = TestGuids.Role.UserManager, Name = nameof(TestGuids.Role.UserManager) };
+        var appClaimRequirement = new AppClaimRequirement(SysClaims.Role.Read, SysClaims.Role.UpdateClaims);
+        var authContext = new AuthorizationHandlerContext([appClaimRequirement], claimsPrincipal, resource);
+
+        await new AppClaimRequirementHandler(authManager)
+            .HandleAsync(authContext);
+
+        Assert.False(authContext.HasSucceeded);
+        Assert.Equal(1, logger.Collector.Count);
+        Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
+        Assert.DoesNotContain(SysClaims.Role.Read, logger.LatestRecord.Message);
     }
 }

--- a/Authorization.Core.Tests/Data/AppDbContext.cs
+++ b/Authorization.Core.Tests/Data/AppDbContext.cs
@@ -1,23 +1,22 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.EntityFrameworkCore;
 
-namespace Authorization.Core.Tests.Data
+namespace Authorization.Core.Tests.Data;
+
+public class AppDbContext : AuthDbContext<AppUser, AppRole>
 {
-    public class AppDbContext : AuthDbContext<AppUser, AppRole>
+    /// <summary>
+    /// Used for testing.
+    /// </summary>
+    public AppDbContext()
+    { }
+
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    { }
+
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        /// <summary>
-        /// Used for testing.
-        /// </summary>
-        public AppDbContext()
-        { }
-
-        public AppDbContext(DbContextOptions<AppDbContext> options)
-            : base(options)
-        { }
-
-        protected override void OnModelCreating(ModelBuilder builder)
-        {
-            base.OnModelCreating(builder);
-        }
+        base.OnModelCreating(builder);
     }
 }

--- a/Authorization.Core.Tests/Data/AppDbContext.cs
+++ b/Authorization.Core.Tests/Data/AppDbContext.cs
@@ -1,6 +1,8 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.EntityFrameworkCore;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.Tests.Data;
 
 public class AppDbContext : AuthDbContext<AppUser, AppRole>

--- a/Authorization.Core.Tests/Data/AppRole.cs
+++ b/Authorization.Core.Tests/Data/AppRole.cs
@@ -1,11 +1,10 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.Data;
 
-namespace Authorization.Core.Tests.Data
-{
-    /// <summary>
-    ///  Describes an application role entity.
-    /// </summary>
-    public class AppRole : AuthRole, IRequiresAuthorization
-    { }
-}
+namespace Authorization.Core.Tests.Data;
+
+/// <summary>
+///  Describes an application role entity.
+/// </summary>
+public class AppRole : AuthRole, IRequiresAuthorization
+{ }

--- a/Authorization.Core.Tests/Data/AppRole.cs
+++ b/Authorization.Core.Tests/Data/AppRole.cs
@@ -1,6 +1,8 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.Data;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.Tests.Data;
 
 /// <summary>

--- a/Authorization.Core.Tests/Data/AppUser.cs
+++ b/Authorization.Core.Tests/Data/AppUser.cs
@@ -1,6 +1,8 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.Data;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.Tests.Data;
 
 /// <summary>
@@ -14,6 +16,7 @@ public class AppUser : AuthUser, IRequiresAuthorization
     public AppUser()
     { }
 
+    /// <summary>
     /// Creates a new instance of the AppUser class with the specified user name.
     /// </summary>
     /// <param name="userName">The user name of the new AppUser.</param>

--- a/Authorization.Core.Tests/Data/AppUser.cs
+++ b/Authorization.Core.Tests/Data/AppUser.cs
@@ -1,23 +1,22 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.Data;
 
-namespace Authorization.Core.Tests.Data
+namespace Authorization.Core.Tests.Data;
+
+/// <summary>
+///  Describes an application user entity.
+/// </summary>
+public class AppUser : AuthUser, IRequiresAuthorization
 {
     /// <summary>
-    ///  Describes an application user entity.
+    /// Creates a new instance of the AppUser class with default values.
     /// </summary>
-    public class AppUser : AuthUser, IRequiresAuthorization
-    {
-        /// <summary>
-        /// Creates a new instance of the AppUser class with default values.
-        /// </summary>
-        public AppUser()
-        { }
+    public AppUser()
+    { }
 
-        /// Creates a new instance of the AppUser class with the specified user name.
-        /// </summary>
-        /// <param name="userName">The user name of the new AppUser.</param>
-        public AppUser(string userName) : base(userName)
-        { }
-    }
+    /// Creates a new instance of the AppUser class with the specified user name.
+    /// </summary>
+    /// <param name="userName">The user name of the new AppUser.</param>
+    public AppUser(string userName) : base(userName)
+    { }
 }

--- a/Authorization.Core.Tests/TestGuids.cs
+++ b/Authorization.Core.Tests/TestGuids.cs
@@ -1,10 +1,12 @@
 ﻿using CRFricke.Authorization.Core;
 
+#pragma warning disable CA1033 // Interface methods should be callable by child types
+#pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.Tests;
 
-#pragma warning disable CA1034 // Nested types should not be visible
-
-public class TestGuids
+public static class TestGuids
 {
     /// <summary>
     /// The Guids of the system Roles.
@@ -24,12 +26,12 @@ public class TestGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for Role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             RoleManager, UserManager
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 }

--- a/Authorization.Core.Tests/TestGuids.cs
+++ b/Authorization.Core.Tests/TestGuids.cs
@@ -1,7 +1,8 @@
 ﻿using CRFricke.Authorization.Core;
-using System.Collections.Generic;
 
 namespace Authorization.Core.Tests;
+
+#pragma warning disable CA1034 // Nested types should not be visible
 
 public class TestGuids
 {
@@ -23,10 +24,10 @@ public class TestGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for Role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids = new()
-        {
+        public static readonly List<string> DefinedGuids =
+        [
             RoleManager, UserManager
-        };
+        ];
 
         ///<inheritdoc/>
         List<string> IDefinesGuids.DefinedGuids => DefinedGuids;

--- a/Authorization.Core.UI.Test.Web/AppClaims.cs
+++ b/Authorization.Core.UI.Test.Web/AppClaims.cs
@@ -1,18 +1,20 @@
 ﻿using CRFricke.Authorization.Core;
 
 #pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable CA1515 // Consider making public types internal
+#pragma warning disable CA1724 // Type names should not match namespaces
 
 namespace Authorization.Core.UI.Test.Web;
 
 /// <summary>
 /// Defines the Claims used by the application.
 /// </summary>
-public class AppClaims
+public sealed class AppClaims
 {
     /// <summary>
     /// Defines the claims required to manipulate Calendar events.
     /// </summary>
-    public class Calendar : IDefinesClaims
+    public sealed class Calendar : IDefinesClaims
     {
         /// <summary>
         /// The user can create CalendarEvent entities.
@@ -42,19 +44,19 @@ public class AppClaims
         /// <summary>
         /// Returns a list of all Claims defined for Calendar entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims =
+        public static readonly IReadOnlyCollection<string> DefinedClaims =
         [
             Create, Delete, Read, Update, List
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
+        IReadOnlyCollection<string> IDefinesClaims.DefinedClaims => DefinedClaims;
     }
 
     /// <summary>
     /// Defines the claims required to manipulate Documents.
     /// </summary>
-    public class Document : IDefinesClaims
+    public sealed class Document : IDefinesClaims
     {
         /// <summary>
         /// The user can upload Documents.
@@ -79,12 +81,12 @@ public class AppClaims
         /// <summary>
         /// Returns a list of all Claims defined for Document entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims =
+        public static readonly IReadOnlyCollection<string> DefinedClaims =
         [
             Upload, Delete, Read, List
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
+        IReadOnlyCollection<string> IDefinesClaims.DefinedClaims => DefinedClaims;
     }
 }

--- a/Authorization.Core.UI.Test.Web/AppClaims.cs
+++ b/Authorization.Core.UI.Test.Web/AppClaims.cs
@@ -1,5 +1,7 @@
 ﻿using CRFricke.Authorization.Core;
 
+#pragma warning disable CA1034 // Nested types should not be visible
+
 namespace Authorization.Core.UI.Test.Web;
 
 /// <summary>
@@ -40,10 +42,10 @@ public class AppClaims
         /// <summary>
         /// Returns a list of all Claims defined for Calendar entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims = new()
-        {
+        public static readonly List<string> DefinedClaims =
+        [
             Create, Delete, Read, Update, List
-        };
+        ];
 
         ///<inheritdoc/>
         List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
@@ -77,10 +79,10 @@ public class AppClaims
         /// <summary>
         /// Returns a list of all Claims defined for Document entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims = new()
-        {
+        public static readonly List<string> DefinedClaims =
+        [
             Upload, Delete, Read, List
-        };
+        ];
 
         ///<inheritdoc/>
         List<string> IDefinesClaims.DefinedClaims => DefinedClaims;

--- a/Authorization.Core.UI.Test.Web/AppGuids.cs
+++ b/Authorization.Core.UI.Test.Web/AppGuids.cs
@@ -1,5 +1,7 @@
 ﻿using CRFricke.Authorization.Core;
 
+#pragma warning disable CA1034 // Nested types should not be visible
+
 namespace Authorization.Core.UI.Test.Web;
 
 /// <summary>
@@ -25,10 +27,10 @@ public class AppGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids = new()
-        {
+        public static readonly List<string> DefinedGuids =
+        [
             CalendarManager, DocumentManager
-        };
+        ];
 
         ///<inheritdoc/>
         List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
@@ -52,10 +54,10 @@ public class AppGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for user entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids = new()
-        {
+        public static readonly List<string> DefinedGuids =
+        [
             CalendarGuy, DocumentGuy
-        };
+        ];
 
         ///<inheritdoc/>
         List<string> IDefinesGuids.DefinedGuids => DefinedGuids;

--- a/Authorization.Core.UI.Test.Web/AppGuids.cs
+++ b/Authorization.Core.UI.Test.Web/AppGuids.cs
@@ -1,18 +1,20 @@
 ﻿using CRFricke.Authorization.Core;
 
 #pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable CA1515 // Consider making public types internal
+#pragma warning disable CA1724 // Type names should not match namespaces
 
 namespace Authorization.Core.UI.Test.Web;
 
 /// <summary>
 /// Defines the Guids used by the application.
 /// </summary>
-public class AppGuids
+public sealed class AppGuids
 {
     /// <summary>
     /// The Guids of the application's default roles.
     /// </summary>
-    public class Role : IDefinesGuids
+    public sealed class Role : IDefinesGuids
     {
         /// <summary>
         /// The Guid assigned to the CalendarManager role.
@@ -27,19 +29,19 @@ public class AppGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             CalendarManager, DocumentManager
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 
     /// <summary>
     /// The Guids of the application's default users.
     /// </summary>
-    public class User : IDefinesGuids
+    public sealed class User : IDefinesGuids
     {
         /// <summary>
         /// The Guid assigned to the <see cref="CalendarGuy"/> user account.
@@ -54,13 +56,13 @@ public class AppGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for user entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             CalendarGuy, DocumentGuy
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 
 }

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Calendar/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Calendar/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
+#pragma warning disable CA1515 // Consider making public types internal
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace Authorization.Core.UI.Test.Web.Admin.Pages.Calendar;

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Calendar/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Calendar/Index.cshtml.cs
@@ -1,13 +1,14 @@
 using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Authorization.Core.UI.Test.Web.Admin.Pages.Calendar
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace Authorization.Core.UI.Test.Web.Admin.Pages.Calendar;
+
+[RequiresClaims(AppClaims.Calendar.List)]
+public class IndexModel : PageModel
 {
-    [RequiresClaims(AppClaims.Calendar.List)]
-    public class IndexModel : PageModel
+    public void OnGet()
     {
-        public void OnGet()
-        {
-        }
     }
 }

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Document/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Document/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
+#pragma warning disable CA1515 // Consider making public types internal
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace Authorization.Core.UI.Test.Web.Admin.Pages.Document;

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Document/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Document/Index.cshtml.cs
@@ -1,13 +1,14 @@
 using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Authorization.Core.UI.Test.Web.Admin.Pages.Document
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace Authorization.Core.UI.Test.Web.Admin.Pages.Document;
+
+[RequiresClaims(AppClaims.Document.List)]
+public class IndexModel : PageModel
 {
-    [RequiresClaims(AppClaims.Document.List)]
-    public class IndexModel : PageModel
+    public void OnGet()
     {
-        public void OnGet()
-        {
-        }
     }
 }

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Index.cshtml.cs
@@ -1,13 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Authorization.Core.UI.Test.Web.Areas.Admin.Pages
+namespace Authorization.Core.UI.Test.Web.Areas.Admin.Pages;
+
+[Authorize()]
+public class IndexModel : PageModel
 {
-    [Authorize()]
-    public class IndexModel : PageModel
+    public void OnGet()
     {
-        public void OnGet()
-        {
-        }
     }
 }

--- a/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Areas/Admin/Pages/Index.cshtml.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Areas.Admin.Pages;
 
 [Authorize()]

--- a/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
+++ b/Authorization.Core.UI.Test.Web/Authorization.Core.UI.Test.Web.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-Authorization.Core.UI.Test.Web-1DF0234F-889F-4F20-95EB-F71E1E1CF878</UserSecretsId>
   </PropertyGroup>
 
@@ -11,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
@@ -3,136 +3,135 @@ using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace Authorization.Core.UI.Test.Web.Data
+namespace Authorization.Core.UI.Test.Web.Data;
+
+public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>
 {
-    public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class using default options.
+    /// </summary>
+    public ApplicationDbContext()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The options to be used by the new <see cref="ApplicationDbContext"/> instance.</param>
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    { }
+
+    /// <inheritdoc/>
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class using default options.
-        /// </summary>
-        public ApplicationDbContext()
-        { }
+        base.OnModelCreating(builder);
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class using the specified options.
-        /// </summary>
-        /// <param name="options">The options to be used by the new <see cref="ApplicationDbContext"/> instance.</param>
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        { }
 
-        /// <inheritdoc/>
-        protected override void OnModelCreating(ModelBuilder builder)
+    /// <inheritdoc/>
+    public override async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
+    {
+        await base.SeedDatabaseAsync(serviceProvider);
+
+        var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
+        var hasher = serviceProvider.GetRequiredService<IPasswordHasher<ApplicationUser>>();
+        var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<ApplicationDbContext>();
+
+        var role = await Roles.FindAsync(AppGuids.Role.CalendarManager);
+        if (role == null)
         {
-            base.OnModelCreating(builder);
+            role = new ApplicationRole
+            {
+                Id = AppGuids.Role.CalendarManager,
+                Name = nameof(AppGuids.Role.CalendarManager),
+                Description = "CalendarManagers are responsible for managing the company's calendar.",
+                NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.CalendarManager))
+            }.SetClaims(AppClaims.Calendar.DefinedClaims);
+
+            await Roles.AddAsync(role);
+            logger.LogInformation(
+                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
+                nameof(ApplicationRole), role.Name, role.Id
+                );
         }
 
-
-        /// <inheritdoc/>
-        public override async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
+        var user = await Users.FindAsync(AppGuids.User.CalendarGuy);
+        if (user == null)
         {
-            await base.SeedDatabaseAsync(serviceProvider);
+            var email = "CalendarGuy@company.com";
 
-            var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
-            var hasher = serviceProvider.GetRequiredService<IPasswordHasher<ApplicationUser>>();
-            var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<ApplicationDbContext>();
-
-            var role = await Roles.FindAsync(AppGuids.Role.CalendarManager);
-            if (role == null)
+            user = new ApplicationUser
             {
-                role = new ApplicationRole
-                {
-                    Id = AppGuids.Role.CalendarManager,
-                    Name = nameof(AppGuids.Role.CalendarManager),
-                    Description = "CalendarManagers are responsible for managing the company's calendar.",
-                    NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.CalendarManager))
-                }.SetClaims(AppClaims.Calendar.DefinedClaims);
+                Id = AppGuids.User.CalendarGuy,
+                Email = email,
+                EmailConfirmed = true,
+                GivenName = "Calendar",
+                LockoutEnabled = false,
+                NormalizedEmail = normalizer.NormalizeEmail(email),
+                NormalizedUserName = normalizer.NormalizeName(email),
+                PasswordHash = hasher.HashPassword(user!, "Calend@rGuy!"),
+                Surname = "Guy",
+                UserName = email
+            }.SetClaims([role.Id]);
 
-                await Roles.AddAsync(role);
-                logger.LogInformation(
-                    "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                    nameof(ApplicationRole), role.Name, role.Id
-                    );
-            }
+            await Users.AddAsync(user);
+            logger.LogInformation(
+                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
+                nameof(ApplicationUser), user.Email, user.Id
+                );
+        }
 
-            var user = await Users.FindAsync(AppGuids.User.CalendarGuy);
-            if (user == null)
+        role = await Roles.FindAsync(AppGuids.Role.DocumentManager);
+        if (role == null)
+        {
+            role = new ApplicationRole
             {
-                var email = "CalendarGuy@company.com";
+                Id = AppGuids.Role.DocumentManager,
+                Name = nameof(AppGuids.Role.DocumentManager),
+                Description = "DocumentManagers are responsible for managing the company's documents.",
+                NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.DocumentManager))
+            }.SetClaims(AppClaims.Document.DefinedClaims);
 
-                user = new ApplicationUser
-                {
-                    Id = AppGuids.User.CalendarGuy,
-                    Email = email,
-                    EmailConfirmed = true,
-                    GivenName = "Calendar",
-                    LockoutEnabled = false,
-                    NormalizedEmail = normalizer.NormalizeEmail(email),
-                    NormalizedUserName = normalizer.NormalizeName(email),
-                    PasswordHash = hasher.HashPassword(user!, "Calend@rGuy!"),
-                    Surname = "Guy",
-                    UserName = email
-                }.SetClaims([role.Id]);
+            await Roles.AddAsync(role);
+            logger.LogInformation(
+                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
+                nameof(ApplicationRole), role.Name, role.Id
+                );
+        }
 
-                await Users.AddAsync(user);
-                logger.LogInformation(
-                    "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
-                    nameof(ApplicationUser), user.Email, user.Id
-                    );
-            }
+        user = await Users.FindAsync(AppGuids.User.DocumentGuy);
+        if (user == null)
+        {
+            var email = "DocumentGuy@company.com";
 
-            role = await Roles.FindAsync(AppGuids.Role.DocumentManager);
-            if (role == null)
+            user = new ApplicationUser
             {
-                role = new ApplicationRole
-                {
-                    Id = AppGuids.Role.DocumentManager,
-                    Name = nameof(AppGuids.Role.DocumentManager),
-                    Description = "DocumentManagers are responsible for managing the company's documents.",
-                    NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.DocumentManager))
-                }.SetClaims(AppClaims.Document.DefinedClaims);
+                Id = AppGuids.User.DocumentGuy,
+                Email = email,
+                EmailConfirmed = true,
+                GivenName = "Document",
+                LockoutEnabled = false,
+                NormalizedEmail = normalizer.NormalizeEmail(email),
+                NormalizedUserName = normalizer.NormalizeName(email),
+                PasswordHash = hasher.HashPassword(user!, "D0cumentGuy!"),
+                Surname = "Guy",
+                UserName = email
+            }.SetClaims([role.Id]);
 
-                await Roles.AddAsync(role);
-                logger.LogInformation(
-                    "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                    nameof(ApplicationRole), role.Name, role.Id
-                    );
-            }
+            await Users.AddAsync(user);
+            logger.LogInformation(
+                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
+                nameof(ApplicationUser), user.Email, user.Id
+                );
+        }
 
-            user = await Users.FindAsync(AppGuids.User.DocumentGuy);
-            if (user == null)
-            {
-                var email = "DocumentGuy@company.com";
-
-                user = new ApplicationUser
-                {
-                    Id = AppGuids.User.DocumentGuy,
-                    Email = email,
-                    EmailConfirmed = true,
-                    GivenName = "Document",
-                    LockoutEnabled = false,
-                    NormalizedEmail = normalizer.NormalizeEmail(email),
-                    NormalizedUserName = normalizer.NormalizeName(email),
-                    PasswordHash = hasher.HashPassword(user!, "D0cumentGuy!"),
-                    Surname = "Guy",
-                    UserName = email
-                }.SetClaims([role.Id]);
-
-                await Users.AddAsync(user);
-                logger.LogInformation(
-                    "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
-                    nameof(ApplicationUser), user.Email, user.Id
-                    );
-            }
-
-            try
-            {
-                await SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "SaveChangesAsync() method failed.");
-            }
+        try
+        {
+            await SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SaveChangesAsync() method failed.");
         }
     }
 }

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
@@ -51,10 +51,7 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
             }.SetClaims<ApplicationRole>(AppClaims.Calendar.DefinedClaims);
 
             await Roles.AddAsync(role).ConfigureAwait(false);
-            logger.LogInformation(
-                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                nameof(ApplicationRole), role.Name, role.Id
-                );
+            logger.LogRoleCreated(nameof(ApplicationRole), role.Name!, role.Id);
         }
 
         var user = await Users.FindAsync(AppGuids.User.CalendarGuy).ConfigureAwait(false);
@@ -77,10 +74,7 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
             }.SetClaims<ApplicationUser>([role.Id]);
 
             await Users.AddAsync(user).ConfigureAwait(false);
-            logger.LogInformation(
-                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
-                nameof(ApplicationUser), user.Email, user.Id
-                );
+            logger.LogUserCreated(nameof(ApplicationUser), user.Email!, user.Id);
         }
 
         role = await Roles.FindAsync(AppGuids.Role.DocumentManager).ConfigureAwait(false);
@@ -95,10 +89,7 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
             }.SetClaims<ApplicationRole>(AppClaims.Document.DefinedClaims);
 
             await Roles.AddAsync(role).ConfigureAwait(false);
-            logger.LogInformation(
-                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                nameof(ApplicationRole), role.Name, role.Id
-                );
+            logger.LogRoleCreated(nameof(ApplicationRole), role.Name!, role.Id);
         }
 
         user = await Users.FindAsync(AppGuids.User.DocumentGuy).ConfigureAwait(false);
@@ -121,10 +112,7 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
             }.SetClaims<ApplicationUser>([role.Id]);
 
             await Users.AddAsync(user).ConfigureAwait(false);
-            logger.LogInformation(
-                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
-                nameof(ApplicationUser), user.Email, user.Id
-                );
+            logger.LogUserCreated(nameof(ApplicationUser), user.Email!, user.Id);
         }
 
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -134,7 +122,7 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "SaveChangesAsync() method failed.");
+            logger.LogSaveChangesFailed(ex);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationDbContext.cs
@@ -3,6 +3,8 @@ using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Data;
 
 public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>
@@ -31,13 +33,13 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
     /// <inheritdoc/>
     public override async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
     {
-        await base.SeedDatabaseAsync(serviceProvider);
+        await base.SeedDatabaseAsync(serviceProvider).ConfigureAwait(false);
 
         var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
         var hasher = serviceProvider.GetRequiredService<IPasswordHasher<ApplicationUser>>();
         var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<ApplicationDbContext>();
 
-        var role = await Roles.FindAsync(AppGuids.Role.CalendarManager);
+        var role = await Roles.FindAsync(AppGuids.Role.CalendarManager).ConfigureAwait(false);
         if (role == null)
         {
             role = new ApplicationRole
@@ -46,16 +48,16 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
                 Name = nameof(AppGuids.Role.CalendarManager),
                 Description = "CalendarManagers are responsible for managing the company's calendar.",
                 NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.CalendarManager))
-            }.SetClaims(AppClaims.Calendar.DefinedClaims);
+            }.SetClaims<ApplicationRole>(AppClaims.Calendar.DefinedClaims);
 
-            await Roles.AddAsync(role);
+            await Roles.AddAsync(role).ConfigureAwait(false);
             logger.LogInformation(
                 "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
                 nameof(ApplicationRole), role.Name, role.Id
                 );
         }
 
-        var user = await Users.FindAsync(AppGuids.User.CalendarGuy);
+        var user = await Users.FindAsync(AppGuids.User.CalendarGuy).ConfigureAwait(false);
         if (user == null)
         {
             var email = "CalendarGuy@company.com";
@@ -72,16 +74,16 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
                 PasswordHash = hasher.HashPassword(user!, "Calend@rGuy!"),
                 Surname = "Guy",
                 UserName = email
-            }.SetClaims([role.Id]);
+            }.SetClaims<ApplicationUser>([role.Id]);
 
-            await Users.AddAsync(user);
+            await Users.AddAsync(user).ConfigureAwait(false);
             logger.LogInformation(
                 "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
                 nameof(ApplicationUser), user.Email, user.Id
                 );
         }
 
-        role = await Roles.FindAsync(AppGuids.Role.DocumentManager);
+        role = await Roles.FindAsync(AppGuids.Role.DocumentManager).ConfigureAwait(false);
         if (role == null)
         {
             role = new ApplicationRole
@@ -90,16 +92,16 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
                 Name = nameof(AppGuids.Role.DocumentManager),
                 Description = "DocumentManagers are responsible for managing the company's documents.",
                 NormalizedName = normalizer.NormalizeName(nameof(AppGuids.Role.DocumentManager))
-            }.SetClaims(AppClaims.Document.DefinedClaims);
+            }.SetClaims<ApplicationRole>(AppClaims.Document.DefinedClaims);
 
-            await Roles.AddAsync(role);
+            await Roles.AddAsync(role).ConfigureAwait(false);
             logger.LogInformation(
                 "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
                 nameof(ApplicationRole), role.Name, role.Id
                 );
         }
 
-        user = await Users.FindAsync(AppGuids.User.DocumentGuy);
+        user = await Users.FindAsync(AppGuids.User.DocumentGuy).ConfigureAwait(false);
         if (user == null)
         {
             var email = "DocumentGuy@company.com";
@@ -116,22 +118,24 @@ public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRo
                 PasswordHash = hasher.HashPassword(user!, "D0cumentGuy!"),
                 Surname = "Guy",
                 UserName = email
-            }.SetClaims([role.Id]);
+            }.SetClaims<ApplicationUser>([role.Id]);
 
-            await Users.AddAsync(user);
+            await Users.AddAsync(user).ConfigureAwait(false);
             logger.LogInformation(
                 "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
                 nameof(ApplicationUser), user.Email, user.Id
                 );
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            await SaveChangesAsync();
+            await SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "SaveChangesAsync() method failed.");
         }
+#pragma warning restore CA1031 // Do not catch general exception types
     }
 }

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationRole.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationRole.cs
@@ -1,5 +1,7 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Data;
 
 public class ApplicationRole : AuthUiRole

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationRole.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationRole.cs
@@ -1,7 +1,6 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 
-namespace Authorization.Core.UI.Test.Web.Data
-{
-    public class ApplicationRole : AuthUiRole
-    { }
-}
+namespace Authorization.Core.UI.Test.Web.Data;
+
+public class ApplicationRole : AuthUiRole
+{ }

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationUser.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationUser.cs
@@ -1,7 +1,6 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 
-namespace Authorization.Core.UI.Test.Web.Data
-{
-    public class ApplicationUser : AuthUiUser
-    { }
-}
+namespace Authorization.Core.UI.Test.Web.Data;
+
+public class ApplicationUser : AuthUiUser
+{ }

--- a/Authorization.Core.UI.Test.Web/Data/ApplicationUser.cs
+++ b/Authorization.Core.UI.Test.Web/Data/ApplicationUser.cs
@@ -1,5 +1,7 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Data;
 
 public class ApplicationUser : AuthUiUser

--- a/Authorization.Core.UI.Test.Web/Data/Migrations/20211117040726_CreateIdentitySchema.cs
+++ b/Authorization.Core.UI.Test.Web/Data/Migrations/20211117040726_CreateIdentitySchema.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+#pragma warning disable CA1515 // Consider making public types internal
 
 namespace Authorization.Core.UI.Test.Web.Data.Migrations
 {

--- a/Authorization.Core.UI.Test.Web/Data/Migrations/20220110002055_AuthCoreUiSchema.cs
+++ b/Authorization.Core.UI.Test.Web/Data/Migrations/20220110002055_AuthCoreUiSchema.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
 
+#pragma warning disable CA1062 // Validate arguments of public methods
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Data.Migrations
 {
     public partial class AuthCoreUiSchema : Migration

--- a/Authorization.Core.UI.Test.Web/LoggerExtensions.cs
+++ b/Authorization.Core.UI.Test.Web/LoggerExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace Authorization.Core.UI.Test.Web;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Information,
+        Message = "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.")]
+    public static partial void LogRoleCreated(
+        this ILogger logger,
+        string roleType,
+        string roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "{UserType} '{UserEmail}' (ID: {UserId}) has been created.")]
+    public static partial void LogUserCreated(
+        this ILogger logger,
+        string userType,
+        string userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Error,
+        Message = "SaveChangesAsync() method failed.")]
+    public static partial void LogSaveChangesFailed(
+        this ILogger logger,
+        Exception exception);
+}

--- a/Authorization.Core.UI.Test.Web/Pages/Error.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Error.cshtml.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Diagnostics;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Pages;
 
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/Authorization.Core.UI.Test.Web/Pages/Error.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Error.cshtml.cs
@@ -2,26 +2,25 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Diagnostics;
 
-namespace Authorization.Core.UI.Test.Web.Pages
+namespace Authorization.Core.UI.Test.Web.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+[IgnoreAntiforgeryToken]
+public class ErrorModel : PageModel
 {
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    [IgnoreAntiforgeryToken]
-    public class ErrorModel : PageModel
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    private readonly ILogger<ErrorModel> _logger;
+
+    public ErrorModel(ILogger<ErrorModel> logger)
     {
-        public string? RequestId { get; set; }
+        _logger = logger;
+    }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
-        private readonly ILogger<ErrorModel> _logger;
-
-        public ErrorModel(ILogger<ErrorModel> logger)
-        {
-            _logger = logger;
-        }
-
-        public void OnGet()
-        {
-            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-        }
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
     }
 }

--- a/Authorization.Core.UI.Test.Web/Pages/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Index.cshtml.cs
@@ -1,20 +1,18 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Authorization.Core.UI.Test.Web.Pages
+namespace Authorization.Core.UI.Test.Web.Pages;
+
+public class IndexModel : PageModel
 {
-    public class IndexModel : PageModel
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(ILogger<IndexModel> logger)
     {
-        private readonly ILogger<IndexModel> _logger;
+        _logger = logger;
+    }
 
-        public IndexModel(ILogger<IndexModel> logger)
-        {
-            _logger = logger;
-        }
+    public void OnGet()
+    {
 
-        public void OnGet()
-        {
-
-        }
     }
 }

--- a/Authorization.Core.UI.Test.Web/Pages/Index.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Index.cshtml.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Test.Web.Pages;
 
 public class IndexModel : PageModel

--- a/Authorization.Core.UI.Test.Web/Pages/Privacy.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Privacy.cshtml.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace Authorization.Core.UI.Test.Web.Pages
+namespace Authorization.Core.UI.Test.Web.Pages;
+
+public class PrivacyModel : PageModel
 {
-    public class PrivacyModel : PageModel
+    private readonly ILogger<PrivacyModel> _logger;
+
+    public PrivacyModel(ILogger<PrivacyModel> logger)
     {
-        private readonly ILogger<PrivacyModel> _logger;
+        _logger = logger;
+    }
 
-        public PrivacyModel(ILogger<PrivacyModel> logger)
-        {
-            _logger = logger;
-        }
-
-        public void OnGet()
-        {
-        }
+    public void OnGet()
+    {
     }
 }

--- a/Authorization.Core.UI.Test.Web/Pages/Privacy.cshtml.cs
+++ b/Authorization.Core.UI.Test.Web/Pages/Privacy.cshtml.cs
@@ -2,6 +2,8 @@
 
 namespace Authorization.Core.UI.Test.Web.Pages;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 public class PrivacyModel : PageModel
 {
     private readonly ILogger<PrivacyModel> _logger;

--- a/Authorization.Core.UI.Test.Web/Program.cs
+++ b/Authorization.Core.UI.Test.Web/Program.cs
@@ -55,6 +55,3 @@ app.UseAuthorization();
 app.MapRazorPages();
 
 app.Run();
-
-
-public partial class Program { }

--- a/Authorization.Core.UI.Tests.Infrastructure/Authorization.Core.UI.Tests.Infrastructure.csproj
+++ b/Authorization.Core.UI.Tests.Infrastructure/Authorization.Core.UI.Tests.Infrastructure.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Authorization.Core.UI.Tests.Infrastructure/Extensions.cs
+++ b/Authorization.Core.UI.Tests.Infrastructure/Extensions.cs
@@ -7,6 +7,8 @@ using System.Security.Claims;
 
 namespace Authorization.Core.UI.Tests.Infrastructure;
 
+#pragma warning disable CA1724 // Type names should not match namespaces
+
 public static class Extensions
 {
     extension(WebAppFactory webAppFixture)
@@ -23,11 +25,11 @@ public static class Extensions
         public async Task DeleteRoleAsync(string roleId)
         {
             var dbContext = webAppFixture.Services.GetRequiredService<ApplicationDbContext>();
-            var dbRole = await dbContext.Roles.FindAsync(roleId);
+            var dbRole = await dbContext.Roles.FindAsync(roleId).ConfigureAwait(false);
             if (dbRole is not null)
             {
                 dbContext.Roles.Remove(dbRole);
-                await dbContext.SaveChangesAsync();
+                await dbContext.SaveChangesAsync().ConfigureAwait(false);
             }
         }
 
@@ -43,11 +45,11 @@ public static class Extensions
         public async Task DeleteUserAsync(string userId)
         {
             var dbContext = webAppFixture.Services.GetRequiredService<ApplicationDbContext>();
-            var dbUser = await dbContext.Users.FindAsync(userId);
+            var dbUser = await dbContext.Users.FindAsync(userId).ConfigureAwait(false);
             if (dbUser is not null)
             {
                 dbContext.Users.Remove(dbUser);
-                await dbContext.SaveChangesAsync();
+                await dbContext.SaveChangesAsync().ConfigureAwait(false);
             }
         }
 
@@ -60,8 +62,10 @@ public static class Extensions
         /// </returns>
         public async Task<ApplicationRole> EnsureRoleAsync(ApplicationRole role)
         {
+            ArgumentNullException.ThrowIfNull(role);
+
             var dbContext = webAppFixture.Services.GetRequiredService<ApplicationDbContext>();
-            var dbRole = await dbContext.Roles.FirstOrDefaultAsync(r => r.Name == role.Name);
+            var dbRole = await dbContext.Roles.FirstOrDefaultAsync(r => r.Name == role.Name).ConfigureAwait(false);
             if (dbRole is not null)
             {
                 return dbRole;
@@ -70,8 +74,8 @@ public static class Extensions
             var normalizer = webAppFixture.Services.GetRequiredService<ILookupNormalizer>();
             role.NormalizedName = normalizer.NormalizeName(role.Name);
 
-            await dbContext.Roles.AddAsync(role);
-            await dbContext.SaveChangesAsync();
+            await dbContext.Roles.AddAsync(role).ConfigureAwait(false);
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
 
             return role;
         }
@@ -91,6 +95,8 @@ public static class Extensions
             Login login,
             string? userClaimValue = null)
         {
+            ArgumentNullException.ThrowIfNull(login);
+
             return EnsureUserAsync(
                 webAppFixture,
                 new() { Email = login.Email },
@@ -112,11 +118,13 @@ public static class Extensions
             Login login,
             string? userClaimValue = null)
         {
+            ArgumentNullException.ThrowIfNull(login);
+
             return await EnsureUserAsync(
                 webAppFixture,
                 new() { Email = login.Email },
                 login.Password,
-                userClaimValue);
+                userClaimValue).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -136,8 +144,10 @@ public static class Extensions
             string password,
             string? userClaimValue = null)
         {
+            ArgumentNullException.ThrowIfNull(user);
+
             var dbContext = webAppFixture.Services.GetRequiredService<ApplicationDbContext>();
-            var dbUser = await dbContext.Users.FirstOrDefaultAsync(u => u.Email == user.Email);
+            var dbUser = await dbContext.Users.FirstOrDefaultAsync(u => u.Email == user.Email).ConfigureAwait(false);
             if (dbUser is not null)
             {
                 return dbUser;
@@ -152,7 +162,7 @@ public static class Extensions
             user.PasswordHash = hasher.HashPassword(user, password);
             user.UserName = user.Email;
 
-            await dbContext.Users.AddAsync(user);
+            await dbContext.Users.AddAsync(user).ConfigureAwait(false);
 
             bool userNeedsRefresh = false;
 
@@ -162,7 +172,7 @@ public static class Extensions
                     uc.UserId == user.Id &&
                     uc.ClaimType == ClaimTypes.Role &&
                     uc.ClaimValue == userClaimValue
-                    );
+                    ).ConfigureAwait(false);
 
                 if (userClaim is null)
                 {
@@ -173,12 +183,12 @@ public static class Extensions
                         ClaimValue = userClaimValue
                     };
 
-                    await dbContext.UserClaims.AddAsync(userClaim);
+                    await dbContext.UserClaims.AddAsync(userClaim).ConfigureAwait(false);
                     userNeedsRefresh = true;
                 }
             }
 
-            await dbContext.SaveChangesAsync();
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
 
             if (userNeedsRefresh)
             {
@@ -202,7 +212,7 @@ public static class Extensions
                 .Where(r => r.Id == roleId)
                 .Include(r => r.Claims)
                 .AsNoTracking()
-                .SingleOrDefaultAsync();
+                .SingleOrDefaultAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -218,7 +228,7 @@ public static class Extensions
                 .Where(r => r.Name == roleName)
                 .Include(r => r.Claims)
                 .AsNoTracking()
-                .SingleOrDefaultAsync();
+                .SingleOrDefaultAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -259,7 +269,7 @@ public static class Extensions
                 .Where(u => u.Email == userEmail)
                 .Include(u => u.Claims)
                 .AsNoTracking()
-                .SingleOrDefaultAsync();
+                .SingleOrDefaultAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -279,7 +289,7 @@ public static class Extensions
                 .Where(u => u.Id == userId)
                 .Include(u => u.Claims)
                 .AsNoTracking()
-                .SingleOrDefaultAsync();
+                .SingleOrDefaultAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -293,7 +303,7 @@ public static class Extensions
         public async Task VerifyRoleExistsAsync(string roleName)
         {
             var dbContext = webAppFixture.Services.GetRequiredService<ApplicationDbContext>();
-            Assert.True(await dbContext.Roles.AnyAsync(r => r.Name == roleName));
+            Assert.True(await dbContext.Roles.AnyAsync(r => r.Name == roleName).ConfigureAwait(false));
         }
     }
 }

--- a/Authorization.Core.UI.Tests.Infrastructure/PlaywrightTestHelpers.cs
+++ b/Authorization.Core.UI.Tests.Infrastructure/PlaywrightTestHelpers.cs
@@ -1,72 +1,71 @@
 ﻿using Microsoft.Playwright;
 using System.Web;
 
-namespace Authorization.Core.UI.Tests.Infrastructure
+namespace Authorization.Core.UI.Tests.Infrastructure;
+
+public class PlaywrightTestHelpers(string baseUrl)
 {
-    public class PlaywrightTestHelpers(string baseUrl)
+    /// <summary>
+    /// Performs an automated login operation on the specified page using the provided user credentials.
+    /// </summary>
+    /// <param name="page">The page instance on which the login process is performed. Cannot be null.</param>
+    /// <param name="login">The user credentials to use for logging in. Cannot be null.</param>
+    /// <param name="returnUrl">An optional URL to redirect to after a successful login. If null, the default post-login page is used.</param>
+    /// <returns>A task that represents the asynchronous login operation.</returns>
+    public async Task LogUserInAsync(IPage page, Login login, string? returnUrl = null)
     {
-        /// <summary>
-        /// Performs an automated login operation on the specified page using the provided user credentials.
-        /// </summary>
-        /// <param name="page">The page instance on which the login process is performed. Cannot be null.</param>
-        /// <param name="login">The user credentials to use for logging in. Cannot be null.</param>
-        /// <param name="returnUrl">An optional URL to redirect to after a successful login. If null, the default post-login page is used.</param>
-        /// <returns>A task that represents the asynchronous login operation.</returns>
-        public async Task LogUserInAsync(IPage page, Login login, string? returnUrl = null)
+        ArgumentNullException.ThrowIfNull(page, nameof(page));
+        ArgumentNullException.ThrowIfNull(login, nameof(login));
+
+        var url = $"{baseUrl}/Identity/Account/Login";
+        if (returnUrl != null)
         {
-            ArgumentNullException.ThrowIfNull(page, nameof(page));
-            ArgumentNullException.ThrowIfNull(login, nameof(login));
-
-            var url = $"{baseUrl}/Identity/Account/Login";
-            if (returnUrl != null)
-            {
-                url += "?ReturnUrl=" + HttpUtility.UrlEncode(returnUrl);
-            }
-
-            await page.GotoAsync(url);
-            await page.GetByPlaceholder("name@example.com").FillAsync(login.Email);
-            await page.GetByPlaceholder("password").FillAsync(login.Password);
-            await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+            url += "?ReturnUrl=" + HttpUtility.UrlEncode(returnUrl);
         }
 
-        /// <summary>
-        /// Registers a new user with the specified email address and logs them in using a predefined password.
-        /// </summary>
-        /// <remarks>This method automates the registration and login process for testing purposes. The password
-        /// used is predefined and not configurable. The method navigates through registration, confirmation, and login
-        /// pages, and waits for network idle states to ensure completion of each step.</remarks>
-        /// <param name="page">The page interface used to automate registration and login actions. Must not be null.</param>
-        /// <param name="userEmail">The email address to use for user registration and login. Cannot be null or empty.</param>
-        /// <returns>A task that represents the asynchronous registration and login operation.</returns>
-        public async Task RegisterAndLogUserInAsync(IPage page, string userEmail)
-        {
-            ArgumentNullException.ThrowIfNull(page, nameof(page));
-            ArgumentException.ThrowIfNullOrEmpty(userEmail, nameof(userEmail));
+        await page.GotoAsync(url);
+        await page.GetByPlaceholder("name@example.com").FillAsync(login.Email);
+        await page.GetByPlaceholder("password").FillAsync(login.Password);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+    }
 
-            var password = "Test123!@#";
+    /// <summary>
+    /// Registers a new user with the specified email address and logs them in using a predefined password.
+    /// </summary>
+    /// <remarks>This method automates the registration and login process for testing purposes. The password
+    /// used is predefined and not configurable. The method navigates through registration, confirmation, and login
+    /// pages, and waits for network idle states to ensure completion of each step.</remarks>
+    /// <param name="page">The page interface used to automate registration and login actions. Must not be null.</param>
+    /// <param name="userEmail">The email address to use for user registration and login. Cannot be null or empty.</param>
+    /// <returns>A task that represents the asynchronous registration and login operation.</returns>
+    public async Task RegisterAndLogUserInAsync(IPage page, string userEmail)
+    {
+        ArgumentNullException.ThrowIfNull(page, nameof(page));
+        ArgumentException.ThrowIfNullOrEmpty(userEmail, nameof(userEmail));
 
-            // Register
-            await page.GotoAsync($"{baseUrl}/Identity/Account/Register");
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        var password = "Test123!@#";
 
-            await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
-            await page.GetByRole(AriaRole.Textbox, new() { Name = "Password", Exact = true }).FillAsync(password);
-            await page.GetByRole(AriaRole.Textbox, new() { Name = "Confirm Password" }).FillAsync(password);
-            await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync();
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        // Register
+        await page.GotoAsync($"{baseUrl}/Identity/Account/Register");
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await page.GetByRole(AriaRole.Heading, new() { Name = "Register confirmation" }).IsVisibleAsync();
-            await page.GetByRole(AriaRole.Link, new() { Name = "Click here to confirm" }).ClickAsync();
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password", Exact = true }).FillAsync(password);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Confirm Password" }).FillAsync(password);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await page.GotoAsync($"{baseUrl}/Identity/Account/Login");
-            await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GetByRole(AriaRole.Heading, new() { Name = "Register confirmation" }).IsVisibleAsync();
+        await page.GetByRole(AriaRole.Link, new() { Name = "Click here to confirm" }).ClickAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
-            await page.GetByRole(AriaRole.Textbox, new() { Name = "Password" }).FillAsync(password);
-            await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await page.GotoAsync($"{baseUrl}/Identity/Account/Login");
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await page.WaitForURLAsync(baseUrl, new() { Timeout = 10_000 });
-        }
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password" }).FillAsync(password);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+
+        await page.WaitForURLAsync(baseUrl, new() { Timeout = 10_000 });
     }
 }

--- a/Authorization.Core.UI.Tests.Infrastructure/PlaywrightTestHelpers.cs
+++ b/Authorization.Core.UI.Tests.Infrastructure/PlaywrightTestHelpers.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Playwright;
 using System.Web;
 
+#pragma warning disable CA1054 // URI-like parameters should not be strings
+
 namespace Authorization.Core.UI.Tests.Infrastructure;
 
 public class PlaywrightTestHelpers(string baseUrl)
@@ -23,10 +25,10 @@ public class PlaywrightTestHelpers(string baseUrl)
             url += "?ReturnUrl=" + HttpUtility.UrlEncode(returnUrl);
         }
 
-        await page.GotoAsync(url);
-        await page.GetByPlaceholder("name@example.com").FillAsync(login.Email);
-        await page.GetByPlaceholder("password").FillAsync(login.Password);
-        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await page.GotoAsync(url).ConfigureAwait(false);
+        await page.GetByPlaceholder("name@example.com").FillAsync(login.Email).ConfigureAwait(false);
+        await page.GetByPlaceholder("password").FillAsync(login.Password).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -46,26 +48,26 @@ public class PlaywrightTestHelpers(string baseUrl)
         var password = "Test123!@#";
 
         // Register
-        await page.GotoAsync($"{baseUrl}/Identity/Account/Register");
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GotoAsync($"{baseUrl}/Identity/Account/Register").ConfigureAwait(false);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
 
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password", Exact = true }).FillAsync(password);
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Confirm Password" }).FillAsync(password);
-        await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync();
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password", Exact = true }).FillAsync(password).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Confirm Password" }).FillAsync(password).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Register" }).ClickAsync().ConfigureAwait(false);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
 
-        await page.GetByRole(AriaRole.Heading, new() { Name = "Register confirmation" }).IsVisibleAsync();
-        await page.GetByRole(AriaRole.Link, new() { Name = "Click here to confirm" }).ClickAsync();
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GetByRole(AriaRole.Heading, new() { Name = "Register confirmation" }).IsVisibleAsync().ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Link, new() { Name = "Click here to confirm" }).ClickAsync().ConfigureAwait(false);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
 
-        await page.GotoAsync($"{baseUrl}/Identity/Account/Login");
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.GotoAsync($"{baseUrl}/Identity/Account/Login").ConfigureAwait(false);
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle).ConfigureAwait(false);
 
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail);
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password" }).FillAsync(password);
-        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync();
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Email" }).FillAsync(userEmail).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password" }).FillAsync(password).ConfigureAwait(false);
+        await page.GetByRole(AriaRole.Button, new() { Name = "Log in" }).ClickAsync().ConfigureAwait(false);
 
-        await page.WaitForURLAsync(baseUrl, new() { Timeout = 10_000 });
+        await page.WaitForURLAsync(baseUrl, new() { Timeout = 10_000 }).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI.Tests.Integration/Authorization.Core.UI.Tests.Integration.csproj
+++ b/Authorization.Core.UI.Tests.Integration/Authorization.Core.UI.Tests.Integration.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+	<IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
 	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
+++ b/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
@@ -13,267 +13,267 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
-namespace Authorization.Core.UI.Tests.Integration
+namespace Authorization.Core.UI.Tests.Integration;
+
+#region Test AuthenticationHandler
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
-    #region Test AuthenticationHandler
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger, UrlEncoder encoder)
+        : base(options, logger, encoder)
+    { }
 
-    public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
-            ILoggerFactory logger, UrlEncoder encoder)
-            : base(options, logger, encoder)
-        { }
-
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        var role = Options.ClaimsIssuer ?? "Administrator";
+        var claims = new[] 
         {
-            var role = Options.ClaimsIssuer ?? "Administrator";
-            var claims = new[] 
-            {
-                new Claim(ClaimTypes.NameIdentifier, "8156bb9b-f56e-4f83-8a11-b0418b843e9b"),
-                new Claim(ClaimTypes.Name, "Admin@company.com"),
-                new Claim(ClaimTypes.Email, "Admin@company.com"),
-                new Claim(ClaimTypes.Role, role),
-            };
-            var identity = new ClaimsIdentity(claims, "Identity.Application");
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, "TestScheme");
+            new Claim(ClaimTypes.NameIdentifier, "8156bb9b-f56e-4f83-8a11-b0418b843e9b"),
+            new Claim(ClaimTypes.Name, "Admin@company.com"),
+            new Claim(ClaimTypes.Email, "Admin@company.com"),
+            new Claim(ClaimTypes.Role, role),
+        };
+        var identity = new ClaimsIdentity(claims, "Identity.Application");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "TestScheme");
 
-            var result = AuthenticateResult.Success(ticket);
+        var result = AuthenticateResult.Success(ticket);
 
-            return Task.FromResult(result);
-        }
+        return Task.FromResult(result);
+    }
+}
+
+#endregion
+
+public class PageAccessTests : IClassFixture<WebAppFactory>
+{
+    public PageAccessTests(WebAppFactory factory)
+    {
+        WebAppFactory = factory;
+        HostUrl = factory.HostUrl;
     }
 
-    #endregion
+    public WebAppFactory WebAppFactory { get; }
 
-    public class PageAccessTests : IClassFixture<WebAppFactory>
+    private string HostUrl { get; }
+
+
+    [Theory(DisplayName = "Can access Management page via friendly area name ")]
+    [MemberData(nameof(Test01Data))]
+    public async Task PageAccessTest01(string endpoint, bool needsId)
     {
-        public PageAccessTests(WebAppFactory factory)
+        var client = CreateClientWithAuthenticationScheme();
+
+        if (needsId)
         {
-            WebAppFactory = factory;
+            var id = (endpoint.Contains("Role"))
+                ? AppGuids.Role.CalendarManager
+                : AppGuids.User.CalendarGuy;
+            endpoint += $"?id={id}";
         }
 
-        public WebAppFactory WebAppFactory { get; }
+        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
 
-        private string HostUrl { get; } = "https://localhost/";
-
-
-        [Theory(DisplayName = "Can access Management page via friendly area name ")]
-        [MemberData(nameof(Test01Data))]
-        public async Task PageAccessTest01(string endpoint, bool needsId)
-        {
-            var client = CreateClientWithAuthenticationScheme();
-
-            if (needsId)
-            {
-                var id = (endpoint.Contains("Role"))
-                    ? AppGuids.Role.CalendarManager
-                    : AppGuids.User.CalendarGuy;
-                endpoint += $"?id={id}";
-            }
-
-            var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Fact(DisplayName = "Can access customer page actually located in friendly name area")]
-        public async Task PageAccessTest02()
-        {
-            var client = CreateClientWithAuthenticationScheme(
-                nameof(AppGuids.Role.CalendarManager)
-                );
-
-            var response = await client.GetAsync("/Admin/Calendar", TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Theory(DisplayName = "Can access Management pages in default area ")]
-        [MemberData(nameof(Test03Data))]
-        public async Task PageAccessTest03Async(string endpoint, bool needsId)
-        {
-            var client = CreateClientWithAuthenticationScheme();
-
-            if (needsId)
-            {
-                var id = (endpoint.Contains("Role"))
-                    ? AppGuids.Role.CalendarManager
-                    : AppGuids.User.CalendarGuy;
-                endpoint += $"?id={id}";
-            }
-
-            var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Theory(DisplayName = "Redirects to AccessDenied page without proper claim ")]
-        [MemberData(nameof(Test04Data))]
-        public async Task PageAccessTest04Async(string endpoint)
-        {
-            var client = WebAppFactory.CreateClient(new WebApplicationFactoryClientOptions
-            {
-                AllowAutoRedirect = false, BaseAddress = new(HostUrl)
-            });
-
-            var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
-        }
-
-        [Theory(DisplayName = "Can access management page with proper claim ")]
-        [MemberData(nameof(Test05Data))]
-        public async Task PageAccessTest05Async(string endpoint, string claim, bool needsId)
-        {
-            using var scope = WebAppFactory.Services.CreateScope();
-            var authManager = scope.ServiceProvider.GetRequiredService<IAuthorizationManager>();
-            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-            var role = dbContext.Roles.Find(AppGuids.Role.DocumentManager)!.SetClaims(claim);
-            dbContext.Roles.Update(role);
-            dbContext.SaveChanges();
-            authManager.RefreshRole(role.Id);
-
-            var client = CreateClientWithAuthenticationScheme(
-                nameof(AppGuids.Role.DocumentManager)
-                );
-
-            if (needsId)
-            {
-                var id = (endpoint.Contains("Role"))
-                    ? AppGuids.Role.CalendarManager
-                    : AppGuids.User.CalendarGuy;
-                endpoint += $"?id={id}";
-            }
-
-            var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Theory(DisplayName = "Returns NotFound for null Id ")]
-        [MemberData(nameof(Test06Data))]
-        public async Task PageAccessTest06Async(string endpoint)
-        {
-            var client = CreateClientWithAuthenticationScheme(
-                nameof(SysGuids.Role.Administrator)
-                );
-
-            var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-        [Theory(DisplayName = "Returns NotFound for non-existing Id ")]
-        [MemberData(nameof(Test06Data))]
-        public async Task PageAccessTest07Async(string endpoint)
-        {
-            var client = CreateClientWithAuthenticationScheme(
-                nameof(SysGuids.Role.Administrator)
-                );
-
-            var response = await client.GetAsync($"{endpoint}?Id={Guid.Empty}", TestContext.Current.CancellationToken);
-
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-
-
-        private HttpClient CreateClientWithAuthenticationScheme(string claimsIssuer = "Administrator", bool allowRedirect = true)
-        {
-            var client = WebAppFactory.WithWebHostBuilder(builder => {
-                builder.ConfigureTestServices(services =>
-                {
-                    services.AddAuthentication(defaultScheme: "TestScheme")
-                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                            "TestScheme", options => { options.ClaimsIssuer = claimsIssuer; });
-                });
-            }).CreateClient(new()
-            {
-                AllowAutoRedirect = allowRedirect,
-                BaseAddress = new(HostUrl)
-            });
-
-            client.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue(scheme: "TestScheme");
-
-            return client;
-        }
-
-
-        public static TheoryData<string, bool> Test01Data => new()
-        {
-            { "/Admin/Role", false },
-            { "/Admin/Role/Create", false },
-            { "/Admin/Role/Delete", true },
-            { "/Admin/Role/Details", true },
-            { "/Admin/Role/Edit", true },
-            { "/Admin/Role/Index", false },
-            { "/Admin/User", false },
-            { "/Admin/User/Create", false },
-            { "/Admin/User/Delete", true },
-            { "/Admin/User/Details", true },
-            { "/Admin/User/Edit", true },
-            { "/Admin/User/Index", false }
-        };
-
-        public static TheoryData<string, bool> Test03Data => new()
-        {
-            { "/Authorization/Role", false },
-            { "/Authorization/Role/Create", false },
-            { "/Authorization/Role/Delete", true },
-            { "/Authorization/Role/Details", true },
-            { "/Authorization/Role/Edit", true },
-            { "/Authorization/Role/Index", false },
-            { "/Authorization/User", false },
-            { "/Authorization/User/Create", false },
-            { "/Authorization/User/Delete", true },
-            { "/Authorization/User/Details", true },
-            { "/Authorization/User/Edit", true },
-            { "/Authorization/User/Index", false }
-        };
-
-        public static TheoryData<string> Test04Data => new()
-        {
-            { "/Admin/Role" },
-            { "/Admin/Role/Create" },
-            { "/Admin/Role/Delete" },
-            { "/Admin/Role/Details" },
-            { "/Admin/Role/Edit" },
-            { "/Admin/Role/Index" },
-            { "/Admin/User" },
-            { "/Admin/User/Create" },
-            { "/Admin/User/Delete" },
-            { "/Admin/User/Details" },
-            { "/Admin/User/Edit" },
-            { "/Admin/User/Index" }
-        };
-
-        public static TheoryData<string, string, bool> Test05Data => new()
-        {
-            { "/Admin/Role", SysClaims.Role.List, false },
-            { "/Admin/Role/Create", SysClaims.Role.Create, false },
-            { "/Admin/Role/Delete", SysClaims.Role.Delete, true },
-            { "/Admin/Role/Details", SysClaims.Role.Read, true },
-            { "/Admin/Role/Edit", SysClaims.Role.Update, true },
-            { "/Admin/Role/Index", SysClaims.Role.List, false },
-            { "/Admin/User", SysClaims.User.List, false },
-            { "/Admin/User/Create", SysClaims.User.Create, false },
-            { "/Admin/User/Delete", SysClaims.User.Delete, true },
-            { "/Admin/User/Details", SysClaims.User.Read, true },
-            { "/Admin/User/Edit", SysClaims.User.Update, true },
-            { "/Admin/User/Index", SysClaims.User.List, false }
-        };
-
-        public static TheoryData<string> Test06Data => new()
-        {
-            { "/Admin/Role/Delete" },
-            { "/Admin/Role/Details" },
-            { "/Admin/Role/Edit" },
-            { "/Admin/User/Delete" },
-            { "/Admin/User/Details" },
-            { "/Admin/User/Edit" }
-        };
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
+
+    [Fact(DisplayName = "Can access customer page actually located in friendly name area")]
+    public async Task PageAccessTest02()
+    {
+        var client = CreateClientWithAuthenticationScheme(
+            nameof(AppGuids.Role.CalendarManager)
+            );
+
+        var response = await client.GetAsync("/Admin/Calendar", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory(DisplayName = "Can access Management pages in default area ")]
+    [MemberData(nameof(Test03Data))]
+    public async Task PageAccessTest03Async(string endpoint, bool needsId)
+    {
+        var client = CreateClientWithAuthenticationScheme();
+
+        if (needsId)
+        {
+            var id = (endpoint.Contains("Role"))
+                ? AppGuids.Role.CalendarManager
+                : AppGuids.User.CalendarGuy;
+            endpoint += $"?id={id}";
+        }
+
+        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory(DisplayName = "Redirects to AccessDenied page without proper claim ")]
+    [MemberData(nameof(Test04Data))]
+    public async Task PageAccessTest04Async(string endpoint)
+    {
+        var client = WebAppFactory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false, BaseAddress = new(HostUrl)
+        });
+
+        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+    }
+
+    [Theory(DisplayName = "Can access management page with proper claim ")]
+    [MemberData(nameof(Test05Data))]
+    public async Task PageAccessTest05Async(string endpoint, string claim, bool needsId)
+    {
+        using var scope = WebAppFactory.Services.CreateScope();
+        var authManager = scope.ServiceProvider.GetRequiredService<IAuthorizationManager>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var role = dbContext.Roles.Find(AppGuids.Role.DocumentManager)!.SetClaims(claim);
+        dbContext.Roles.Update(role);
+        dbContext.SaveChanges();
+        authManager.RefreshRole(role.Id);
+
+        var client = CreateClientWithAuthenticationScheme(
+            nameof(AppGuids.Role.DocumentManager)
+            );
+
+        if (needsId)
+        {
+            var id = (endpoint.Contains("Role"))
+                ? AppGuids.Role.CalendarManager
+                : AppGuids.User.CalendarGuy;
+            endpoint += $"?id={id}";
+        }
+
+        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory(DisplayName = "Returns NotFound for null Id ")]
+    [MemberData(nameof(Test06Data))]
+    public async Task PageAccessTest06Async(string endpoint)
+    {
+        var client = CreateClientWithAuthenticationScheme(
+            nameof(SysGuids.Role.Administrator)
+            );
+
+        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory(DisplayName = "Returns NotFound for non-existing Id ")]
+    [MemberData(nameof(Test06Data))]
+    public async Task PageAccessTest07Async(string endpoint)
+    {
+        var client = CreateClientWithAuthenticationScheme(
+            nameof(SysGuids.Role.Administrator)
+            );
+
+        var response = await client.GetAsync($"{endpoint}?Id={Guid.Empty}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+
+
+    private HttpClient CreateClientWithAuthenticationScheme(string claimsIssuer = "Administrator", bool allowRedirect = true)
+    {
+        var client = WebAppFactory.WithWebHostBuilder(builder => {
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(defaultScheme: "TestScheme")
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        "TestScheme", options => { options.ClaimsIssuer = claimsIssuer; });
+            });
+        }).CreateClient(new()
+        {
+            AllowAutoRedirect = allowRedirect,
+            BaseAddress = new(HostUrl)
+        });
+
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(scheme: "TestScheme");
+
+        return client;
+    }
+
+
+    public static TheoryData<string, bool> Test01Data => new()
+    {
+        { "/Admin/Role", false },
+        { "/Admin/Role/Create", false },
+        { "/Admin/Role/Delete", true },
+        { "/Admin/Role/Details", true },
+        { "/Admin/Role/Edit", true },
+        { "/Admin/Role/Index", false },
+        { "/Admin/User", false },
+        { "/Admin/User/Create", false },
+        { "/Admin/User/Delete", true },
+        { "/Admin/User/Details", true },
+        { "/Admin/User/Edit", true },
+        { "/Admin/User/Index", false }
+    };
+
+    public static TheoryData<string, bool> Test03Data => new()
+    {
+        { "/Authorization/Role", false },
+        { "/Authorization/Role/Create", false },
+        { "/Authorization/Role/Delete", true },
+        { "/Authorization/Role/Details", true },
+        { "/Authorization/Role/Edit", true },
+        { "/Authorization/Role/Index", false },
+        { "/Authorization/User", false },
+        { "/Authorization/User/Create", false },
+        { "/Authorization/User/Delete", true },
+        { "/Authorization/User/Details", true },
+        { "/Authorization/User/Edit", true },
+        { "/Authorization/User/Index", false }
+    };
+
+    public static TheoryData<string> Test04Data => new()
+    {
+        { "/Admin/Role" },
+        { "/Admin/Role/Create" },
+        { "/Admin/Role/Delete" },
+        { "/Admin/Role/Details" },
+        { "/Admin/Role/Edit" },
+        { "/Admin/Role/Index" },
+        { "/Admin/User" },
+        { "/Admin/User/Create" },
+        { "/Admin/User/Delete" },
+        { "/Admin/User/Details" },
+        { "/Admin/User/Edit" },
+        { "/Admin/User/Index" }
+    };
+
+    public static TheoryData<string, string, bool> Test05Data => new()
+    {
+        { "/Admin/Role", SysClaims.Role.List, false },
+        { "/Admin/Role/Create", SysClaims.Role.Create, false },
+        { "/Admin/Role/Delete", SysClaims.Role.Delete, true },
+        { "/Admin/Role/Details", SysClaims.Role.Read, true },
+        { "/Admin/Role/Edit", SysClaims.Role.Update, true },
+        { "/Admin/Role/Index", SysClaims.Role.List, false },
+        { "/Admin/User", SysClaims.User.List, false },
+        { "/Admin/User/Create", SysClaims.User.Create, false },
+        { "/Admin/User/Delete", SysClaims.User.Delete, true },
+        { "/Admin/User/Details", SysClaims.User.Read, true },
+        { "/Admin/User/Edit", SysClaims.User.Update, true },
+        { "/Admin/User/Index", SysClaims.User.List, false }
+    };
+
+    public static TheoryData<string> Test06Data => new()
+    {
+        { "/Admin/Role/Delete" },
+        { "/Admin/Role/Details" },
+        { "/Admin/Role/Edit" },
+        { "/Admin/User/Delete" },
+        { "/Admin/User/Details" },
+        { "/Admin/User/Edit" }
+    };
 }

--- a/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
+++ b/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
@@ -13,6 +13,9 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
+#pragma warning disable CA1062 // Validate arguments of public methods
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Tests.Integration;
 
 #region Test AuthenticationHandler
@@ -50,6 +53,8 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
 {
     public PageAccessTests(WebAppFactory factory)
     {
+        ArgumentNullException.ThrowIfNull(factory);
+
         WebAppFactory = factory;
         HostUrl = factory.HostUrl;
     }
@@ -63,17 +68,19 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
     [MemberData(nameof(Test01Data))]
     public async Task PageAccessTest01(string endpoint, bool needsId)
     {
+        ArgumentNullException.ThrowIfNull(endpoint);
+
         var client = CreateClientWithAuthenticationScheme();
 
         if (needsId)
         {
-            var id = (endpoint.Contains("Role"))
+            var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
             endpoint += $"?id={id}";
         }
 
-        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -85,7 +92,7 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
             nameof(AppGuids.Role.CalendarManager)
             );
 
-        var response = await client.GetAsync("/Admin/Calendar", TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri("/Admin/Calendar", UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -98,13 +105,13 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
 
         if (needsId)
         {
-            var id = (endpoint.Contains("Role"))
+            var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
             endpoint += $"?id={id}";
         }
 
-        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -118,7 +125,7 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
             AllowAutoRedirect = false, BaseAddress = new(HostUrl)
         });
 
-        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
     }
@@ -131,9 +138,11 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
         var authManager = scope.ServiceProvider.GetRequiredService<IAuthorizationManager>();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-        var role = dbContext.Roles.Find(AppGuids.Role.DocumentManager)!.SetClaims(claim);
+        var role = (
+            await dbContext.Roles.FindAsync([AppGuids.Role.DocumentManager], TestContext.Current.CancellationToken)
+            )!.SetClaims<ApplicationRole>(claim);
         dbContext.Roles.Update(role);
-        dbContext.SaveChanges();
+        await dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         authManager.RefreshRole(role.Id);
 
         var client = CreateClientWithAuthenticationScheme(
@@ -142,13 +151,13 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
 
         if (needsId)
         {
-            var id = (endpoint.Contains("Role"))
+            var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
             endpoint += $"?id={id}";
         }
 
-        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -161,7 +170,7 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
             nameof(SysGuids.Role.Administrator)
             );
 
-        var response = await client.GetAsync(endpoint, TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -174,7 +183,7 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
             nameof(SysGuids.Role.Administrator)
             );
 
-        var response = await client.GetAsync($"{endpoint}?Id={Guid.Empty}", TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri($"{endpoint}?Id={Guid.Empty}", UriKind.Relative), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }

--- a/Authorization.Core.UI.Tests.Playwright/Authorization.Core.UI.Tests.Playwright.csproj
+++ b/Authorization.Core.UI.Tests.Playwright/Authorization.Core.UI.Tests.Playwright.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
 	<OutputType>Exe</OutputType>
 	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/Authorization.Core.UI.Tests.Playwright/Infrastructure/PlaywrightCollection.cs
+++ b/Authorization.Core.UI.Tests.Playwright/Infrastructure/PlaywrightCollection.cs
@@ -1,5 +1,8 @@
 ﻿using CRFricke.Test.Support.Infrastructure;
 
+#pragma warning disable CA1515 // Consider making public types internal
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+
 namespace Authorization.Core.UI.Tests.Playwright.Infrastructure;
 
 /// <summary>

--- a/Authorization.Core.UI.Tests.Playwright/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests.Playwright/RoleManagementTests.cs
@@ -58,7 +58,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         }.SetClaims(AppClaims.Calendar.List, AppClaims.Document.List, SysClaims.Role.List, SysClaims.User.List);
 
         await Page.GetByLabel("Name").FillAsync(role.Name!);
-        await Page.GetByLabel("Description").FillAsync(role.Description);
+        await Page.GetByLabel("Description").FillAsync(role.Description!);
         await Page.GetByLabel("Search:").FillAsync("List");
         foreach (var claim in role.Claims)
         {
@@ -220,7 +220,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await Assertions.Expect(locator).ToHaveValueAsync(role.Name!);
 
         locator = Page.GetByRole(AriaRole.Textbox).Nth(2);
-        await Assertions.Expect(locator).ToHaveValueAsync(role.Description);
+        await Assertions.Expect(locator).ToHaveValueAsync(role.Description!);
 
         // Verify assigned User is displayed
         locator = Page.GetByRole(AriaRole.Cell, new() { Name = login.Email });

--- a/Authorization.Core.UI.Tests.Playwright/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests.Playwright/RoleManagementTests.cs
@@ -11,7 +11,9 @@ namespace Authorization.Core.UI.Tests.Playwright;
 [Collection("Playwright")]
 public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLifetime
 {
+#pragma warning disable CA1056 // URI-like properties should not be strings
     public string BaseUrl { get; private set; } = null!;
+#pragma warning restore CA1056 // URI-like properties should not be strings
 
     private IPage Page { get; set; } = null!;
 
@@ -21,7 +23,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
     public async ValueTask InitializeAsync()
     {
-        Page = await playwrightFixture.CreatePageAsync();
+        Page = await playwrightFixture.CreatePageAsync().ConfigureAwait(false);
 
         WebAppFactory = new WebAppFactory();
         WebAppFactory.UseKestrel();
@@ -35,8 +37,8 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
     public async ValueTask DisposeAsync()
     {
-        await Page.CloseAsync();
-        await WebAppFactory.DisposeAsync();
+        await Page.CloseAsync().ConfigureAwait(false);
+        await WebAppFactory.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }
 
@@ -45,17 +47,17 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
     {
         await LogUserInAsync(Logins.RoleManager, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Link, new() { Name = "Create New" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Create Role", title);
+        Assert.Contains("Create Role", title, StringComparison.Ordinal);
 
         var role = new ApplicationRole
         {
             Name = "Test01Role",
             Description = "Test Role"
-        }.SetClaims(AppClaims.Calendar.List, AppClaims.Document.List, SysClaims.Role.List, SysClaims.User.List);
+        }.SetClaims<ApplicationRole>(AppClaims.Calendar.List, AppClaims.Document.List, SysClaims.Role.List, SysClaims.User.List);
 
         await Page.GetByLabel("Name").FillAsync(role.Name!);
         await Page.GetByLabel("Description").FillAsync(role.Description!);
@@ -67,7 +69,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         }
         await Page.GetByRole(AriaRole.Button, new() { Name = "Create" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"Role '{role.Name}' successfully created." })
@@ -90,14 +92,14 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.RoleManager, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
             .GetByRole(AriaRole.Link, new() { Name = "View" })
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Role Details", title);
+        Assert.Contains("Role Details", title, StringComparison.Ordinal);
 
         await Assertions.Expect(Page.GetByLabel("Id")).ToHaveValueAsync(role.Id);
         await Assertions.Expect(Page.GetByLabel("Name")).ToHaveValueAsync(role.Name!);
@@ -124,19 +126,19 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test03Role",
             Description = "Can list and view news items."
-        }.SetClaims(AppClaims.Calendar.List, AppClaims.Calendar.Read);
+        }.SetClaims<ApplicationRole>(AppClaims.Calendar.List, AppClaims.Calendar.Read);
         await WebAppFactory.EnsureRoleAsync(role);
 
         await LogUserInAsync(Logins.Administrator, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
             .GetByRole(AriaRole.Link, new() { Name = "Edit" })
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Edit Role", title);
+        Assert.Contains("Edit Role", title, StringComparison.Ordinal);
 
         var locator = Page.GetByLabel(nameof(role.Name));
         await Assertions.Expect(locator).ToHaveValueAsync(role.Name ?? string.Empty);
@@ -170,11 +172,11 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
         locator = Page.GetByRole(AriaRole.Heading, new() { Name = $"Role '{role.Name}' was successfully updated." });
         Assert.NotNull(locator);
 
-        role.SetClaims(AppClaims.Calendar.DefinedClaims);
+        role.SetClaims<ApplicationRole>(AppClaims.Calendar.DefinedClaims);
 
         var dbRole = await WebAppFactory.GetRoleByIdAsync(role.Id);
         Assert.NotNull(dbRole);
@@ -196,7 +198,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test04Role",
             Description = "Can create, delete, list, read, and update calendar items."
-        }.SetClaims(AppClaims.Calendar.DefinedClaims);
+        }.SetClaims<ApplicationRole>(AppClaims.Calendar.DefinedClaims);
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test04User@company.com", "Test04pa$$");
@@ -204,14 +206,14 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.RoleManager, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
             .GetByRole(AriaRole.Link, new() { Name = "Delete" })
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete Role", title);
+        Assert.Contains("Delete Role", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Textbox).Nth(0);
         await Assertions.Expect(locator).ToHaveValueAsync(role.Id);
@@ -227,7 +229,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await Assertions.Expect(locator).ToHaveCountAsync(1);
         await Page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).First.ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"Role '{role.Name}' successfully deleted." })
@@ -239,14 +241,14 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
     {
         await LogUserInAsync(Logins.RoleManager, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = nameof(AppGuids.Role.DocumentManager) })
             .GetByRole(AriaRole.Link, new() { Name = "Delete" })
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete Role", title);
+        Assert.Contains("Delete Role", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = "System Roles may not be deleted!" })
@@ -265,20 +267,20 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.RoleManager, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
             .GetByRole(AriaRole.Link, new() { Name = "Delete" })
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete Role", title);
+        Assert.Contains("Delete Role", title, StringComparison.Ordinal);
 
         await WebAppFactory.DeleteRoleAsync(role.Id);
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).First.ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"Error: Role '{role.Name}' was not found in the database." })
@@ -292,7 +294,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "CalendarReader",
             Description = "Test Role"
-        }.SetClaims(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Create]));
+        }.SetClaims<ApplicationRole>(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Create]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test07User@company.com", "TestO7pa$$");
@@ -300,7 +302,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Link, new() { Name = "Create New" });
         await Assertions.Expect(locator).ToBeDisabledAsync();
@@ -313,7 +315,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test08Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Update]));
+        }.SetClaims<ApplicationRole>(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Update]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test08User@company.com", "TestO8pa$$");
@@ -321,7 +323,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
@@ -336,7 +338,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test09Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Read]));
+        }.SetClaims<ApplicationRole>(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Read]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test09User@company.com", "TestO9pa$$");
@@ -344,7 +346,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
@@ -359,7 +361,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test10Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Delete]));
+        }.SetClaims<ApplicationRole>(SysClaims.Role.DefinedClaims.Except([SysClaims.Role.Delete]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test10User@company.com", "Test10pa$$");
@@ -367,7 +369,7 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/Role");
         var title = await Page.TitleAsync();
-        Assert.Contains("Role Management", title);
+        Assert.Contains("Role Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = role!.Name })
@@ -383,6 +385,6 @@ public class RoleManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
     /// <returns>A task that represents the asynchronous login operation.</returns>
     private async Task LogUserInAsync(Login login, string? returnUrl = null)
     {
-        await TestHelpers.LogUserInAsync(Page, login, returnUrl);
+        await TestHelpers.LogUserInAsync(Page, login, returnUrl).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
@@ -171,12 +171,12 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await locator.FillAsync(user.Email);
 
         locator = Page.GetByLabel("First Name");
-        await Assertions.Expect(locator).ToHaveValueAsync(user.GivenName);
+        await Assertions.Expect(locator).ToHaveValueAsync(user.GivenName!);
         user.GivenName = "Test";
         await locator.FillAsync(user.GivenName);
 
         locator = Page.GetByLabel("Last Name");
-        await Assertions.Expect(locator).ToHaveValueAsync(user.Surname);
+        await Assertions.Expect(locator).ToHaveValueAsync(user.Surname!);
         user.Surname = "User";
         await locator.FillAsync(user.Surname);
 
@@ -246,8 +246,8 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await Assertions.Expect(Page.GetByLabel("Id")).ToHaveValueAsync(user.Id);
         await Assertions.Expect(Page.Locator("#UserModel_Email").Nth(1)).ToHaveValueAsync(user.Email ?? string.Empty);
-        await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName);
-        await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname);
+        await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName!);
+        await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname!);
         await Assertions.Expect(Page.GetByLabel("Phone Number", new() { Exact = true })).ToHaveValueAsync(user.PhoneNumber ?? string.Empty);
         await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString() ?? string.Empty);
         await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString() ?? string.Empty);

--- a/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
@@ -6,6 +6,7 @@ using CRFricke.Test.Support.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
+using System.Globalization;
 
 namespace Authorization.Core.UI.Tests.Playwright;
 
@@ -13,7 +14,9 @@ namespace Authorization.Core.UI.Tests.Playwright;
 public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLifetime
 {
 
+#pragma warning disable CA1056 // URI-like properties should not be strings
     public string BaseUrl { get; private set; } = null!;
+#pragma warning restore CA1056 // URI-like properties should not be strings
 
     private IPage Page { get; set; } = null!;
 
@@ -26,7 +29,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
     public async ValueTask InitializeAsync()
     {
-        Page = await playwrightFixture.CreatePageAsync();
+        Page = await playwrightFixture.CreatePageAsync().ConfigureAwait(false);
         WebAppFactory = new WebAppFactory();
         WebAppFactory.UseKestrel();
         WebAppFactory.StartServer();
@@ -37,13 +40,13 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         using var scope = WebAppFactory.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        RoleDictionary = await dbContext.Roles.ToDictionaryAsync(ar => ar.Id, ar => ar);
+        RoleDictionary = await dbContext.Roles.ToDictionaryAsync(ar => ar.Id, ar => ar).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-        await Page.CloseAsync();
-        await WebAppFactory.DisposeAsync();
+        await Page.CloseAsync().ConfigureAwait(false);
+        await WebAppFactory.DisposeAsync().ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }
 
@@ -53,11 +56,11 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
     {
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Link, new() { Name = "Create New" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Create User", title);
+        Assert.Contains("Create User", title, StringComparison.Ordinal);
 
         var userEmail = "Test01User@company.com";
         var userPassword = "SuperSecret01!";
@@ -80,7 +83,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Create" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"User '{userEmail}' successfully created." })
@@ -113,22 +116,22 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = user!.Email })
             .GetByLabel("View")
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Details", title);
+        Assert.Contains("User Details", title, StringComparison.Ordinal);
 
         await Assertions.Expect(Page.GetByLabel("Id")).ToHaveValueAsync(user.Id);
         await Assertions.Expect(Page.GetByLabel("Email", new() { Exact = true })).ToHaveValueAsync(user.Email);
         await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName);
         await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname);
         await Assertions.Expect(Page.GetByLabel("Phone Number", new() { Exact = true })).ToHaveValueAsync(user.PhoneNumber);
-        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString() ?? string.Empty);
-        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString() ?? string.Empty);
+        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString("M/d/yyyy h:mm:ss tt K", CultureInfo.InvariantCulture) ?? string.Empty);
+        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
 
         var rows = Page.GetByRole(AriaRole.Row)
             .GetByRole(AriaRole.Checkbox, new() { Checked = true });
@@ -151,19 +154,19 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
             Surname = "User",
             PhoneNumber = "(123) 456-7890",
             LockoutEnd = DateTimeOffset.UtcNow.AddDays(1)
-        }.SetClaims(SysUiGuids.Role.RoleManager);
+        }.SetClaims<ApplicationUser>(SysUiGuids.Role.RoleManager);
 
         await WebAppFactory.EnsureUserAsync(user, "SuperSecret03!");
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = user!.Email })
             .GetByLabel("Edit")
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Edit User", title);
+        Assert.Contains("Edit User", title, StringComparison.Ordinal);
 
         var locator = Page.GetByLabel("Email", new() { Exact = true });
         await Assertions.Expect(locator).ToHaveValueAsync(user.Email!);
@@ -186,7 +189,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await locator.FillAsync(user.PhoneNumber);
 
         locator = Page.GetByLabel("Lockout Ends On (UTC)");
-        await Assertions.Expect(locator).ToHaveValueAsync($"{user.LockoutEnd!.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff").TrimEnd('0')}");
+        await Assertions.Expect(locator).ToHaveValueAsync($"{user.LockoutEnd!.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture).TrimEnd('0')}");
         user.LockoutEnd = null;
         await locator.FillAsync(string.Empty);
 
@@ -200,7 +203,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Save" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
         locator = Page.GetByRole(AriaRole.Heading, new() { Name = $"User '{user.Email}' successfully updated." });
         Assert.NotNull(locator);
 
@@ -230,27 +233,27 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
             Surname = "User",
             PhoneNumber = "(123) 456-7890",
             LockoutEnd = DateTime.UtcNow.AddDays(1)
-        }.SetClaims(userRole.Id);
+        }.SetClaims<ApplicationUser>(userRole.Id);
         await WebAppFactory.EnsureUserAsync(user, "SuperSecret04!");
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = user.Email })
             .GetByLabel("Delete")
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete User", title);
+        Assert.Contains("Delete User", title, StringComparison.Ordinal);
 
         await Assertions.Expect(Page.GetByLabel("Id")).ToHaveValueAsync(user.Id);
         await Assertions.Expect(Page.Locator("#UserModel_Email").Nth(1)).ToHaveValueAsync(user.Email ?? string.Empty);
         await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName!);
         await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname!);
         await Assertions.Expect(Page.GetByLabel("Phone Number", new() { Exact = true })).ToHaveValueAsync(user.PhoneNumber ?? string.Empty);
-        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString() ?? string.Empty);
-        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString() ?? string.Empty);
+        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString("M/d/yyyy h:mm:ss tt K", CultureInfo.InvariantCulture) ?? string.Empty);
+        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
 
         var rows = Page.GetByRole(AriaRole.Row)
             .GetByRole(AriaRole.Checkbox, new() { Checked = true });
@@ -264,7 +267,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"User '{user.Email}' successfully deleted." })
             ).ToHaveCountAsync(1);
@@ -279,14 +282,14 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = user!.Email })
             .GetByLabel("Delete")
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete User", title);
+        Assert.Contains("Delete User", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = "System accounts may not be deleted!" })
@@ -305,19 +308,19 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
         await Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = user!.Email })
             .GetByLabel("Delete")
             .ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Delete User", title);
+        Assert.Contains("Delete User", title, StringComparison.Ordinal);
 
         await WebAppFactory.DeleteUserAsync(user.Id);
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).First.ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"Error: User '{user.Email}' was not found in the database." })
@@ -331,32 +334,32 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Link, new() { Name = "Create New" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Create User", title);
+        Assert.Contains("Create User", title, StringComparison.Ordinal);
         await Page.GetByLabel("Email").FillAsync(login.Email);
         await Page.GetByLabel("Password", new() { Exact = true }).FillAsync(login.Password);
         await Page.GetByLabel("Confirm password").FillAsync(login.Password);
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Create" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Assertions.Expect(
             Page.GetByRole(AriaRole.Heading, new() { Name = $"User '{login.Email}' successfully created." })
             ).ToHaveCountAsync(1);
         title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
         await Page.GotoAsync(BaseUrl);
         await Page.GetByRole(AriaRole.Button, new() { Name = "Logout" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Log out", title);
+        Assert.Contains("Log out", title, StringComparison.Ordinal);
 
         await LogUserInAsync(login, "/Admin");
         title = await Page.TitleAsync();
-        Assert.Contains("Administration", title);
+        Assert.Contains("Administration", title, StringComparison.Ordinal);
 
         await Assertions.Expect(Page.GetByTitle("Manage")).ToContainTextAsync(login.Email);
     }
@@ -368,24 +371,24 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(Logins.Administrator, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         await Page.GetByRole(AriaRole.Link, new() { Name = "Create New" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Create User", title);
+        Assert.Contains("Create User", title, StringComparison.Ordinal  );
         await Page.GetByLabel("Email").FillAsync(login.Email);
         await Page.GetByLabel("Password", new() { Exact = true }).FillAsync(login.Password);
         await Page.GetByLabel("Confirm password").FillAsync(login.Password);
 
         await Page.GetByRole(AriaRole.Button, new() { Name = "Create" }).ClickAsync();
         title = await Page.TitleAsync();
-        Assert.Contains("Create User", title);
+        Assert.Contains("Create User", title, StringComparison.Ordinal);
 
         var errors = await Page.Locator(".validation-summary-errors").AllInnerTextsAsync();
         Assert.Multiple(() =>
         {
-            Assert.Contains(errors, m => m.Contains("one digit"));
-            Assert.Contains(errors, m => m.Contains("one upper"));
+            Assert.Contains(errors, m => m.Contains("one digit", StringComparison.Ordinal));
+            Assert.Contains(errors, m => m.Contains("one upper", StringComparison.Ordinal));
         });
     }
 
@@ -396,7 +399,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test09Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.User.DefinedClaims.Except([SysClaims.User.Create]));
+        }.SetClaims<ApplicationRole>(SysClaims.User.DefinedClaims.Except([SysClaims.User.Create]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test09User@company.com", "Test09pa$$");
@@ -404,7 +407,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Link, new() { Name = "Create New" });
         await Assertions.Expect(locator).ToBeDisabledAsync();
@@ -417,7 +420,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test10Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.User.DefinedClaims.Except([SysClaims.User.Update]));
+        }.SetClaims<ApplicationRole>(SysClaims.User.DefinedClaims.Except([SysClaims.User.Update]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test10User@company.com", "Test10pa$$");
@@ -425,7 +428,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = login.Email })
@@ -440,7 +443,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test11Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.User.DefinedClaims.Except([SysClaims.User.Read]));
+        }.SetClaims<ApplicationRole>(SysClaims.User.DefinedClaims.Except([SysClaims.User.Read]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test11User@company.com", "Test11pa$$");
@@ -448,7 +451,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = login.Email })
@@ -463,7 +466,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         {
             Name = "Test12Role",
             Description = "Test Role"
-        }.SetClaims(SysClaims.User.DefinedClaims.Except([SysClaims.User.Delete]));
+        }.SetClaims<ApplicationRole>(SysClaims.User.DefinedClaims.Except([SysClaims.User.Delete]));
         await WebAppFactory.EnsureRoleAsync(role);
 
         var login = new Login("Test12User@company.com", "Test12pa$$");
@@ -471,7 +474,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
 
         await LogUserInAsync(login, "/Admin/User");
         var title = await Page.TitleAsync();
-        Assert.Contains("User Management", title);
+        Assert.Contains("User Management", title, StringComparison.Ordinal);
 
         var locator = Page.GetByRole(AriaRole.Row)
             .Filter(new() { HasText = login.Email })
@@ -488,6 +491,6 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
     /// <returns>A task that represents the asynchronous login operation.</returns>
     private async Task LogUserInAsync(Login login, string? returnUrl = null)
     {
-        await TestHelpers.LogUserInAsync(Page, login, returnUrl);
+        await TestHelpers.LogUserInAsync(Page, login, returnUrl).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests.Playwright/UserManagementTests.cs
@@ -130,8 +130,8 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName);
         await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname);
         await Assertions.Expect(Page.GetByLabel("Phone Number", new() { Exact = true })).ToHaveValueAsync(user.PhoneNumber);
-        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString("M/d/yyyy h:mm:ss tt K", CultureInfo.InvariantCulture) ?? string.Empty);
-        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
+        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
 
         var rows = Page.GetByRole(AriaRole.Row)
             .GetByRole(AriaRole.Checkbox, new() { Checked = true });
@@ -189,7 +189,7 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await locator.FillAsync(user.PhoneNumber);
 
         locator = Page.GetByLabel("Lockout Ends On (UTC)");
-        await Assertions.Expect(locator).ToHaveValueAsync($"{user.LockoutEnd!.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture).TrimEnd('0')}");
+        await Assertions.Expect(locator).ToHaveValueAsync($"{user.LockoutEnd!.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.CurrentCulture).TrimEnd('0')}");
         user.LockoutEnd = null;
         await locator.FillAsync(string.Empty);
 
@@ -252,8 +252,8 @@ public class UserManagementTests(PlaywrightFixture playwrightFixture) : IAsyncLi
         await Assertions.Expect(Page.GetByLabel("First Name")).ToHaveValueAsync(user.GivenName!);
         await Assertions.Expect(Page.GetByLabel("Last Name")).ToHaveValueAsync(user.Surname!);
         await Assertions.Expect(Page.GetByLabel("Phone Number", new() { Exact = true })).ToHaveValueAsync(user.PhoneNumber ?? string.Empty);
-        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString("M/d/yyyy h:mm:ss tt K", CultureInfo.InvariantCulture) ?? string.Empty);
-        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+        await Assertions.Expect(Page.Locator("#UserModel_LockoutEnd")).ToHaveValueAsync(user.LockoutEnd?.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
+        await Assertions.Expect(Page.GetByLabel("Failed Logins")).ToHaveValueAsync(user.AccessFailedCount.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
 
         var rows = Page.GetByRole(AriaRole.Row)
             .GetByRole(AriaRole.Checkbox, new() { Checked = true });

--- a/Authorization.Core.UI.Tests/Authorization.Core.UI.Tests.csproj
+++ b/Authorization.Core.UI.Tests/Authorization.Core.UI.Tests.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+	<IsPackable>false</IsPackable>
 	<OutputType>Exe</OutputType>
 	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>

--- a/Authorization.Core.UI.Tests/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationDbContext.cs
@@ -1,6 +1,8 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.EntityFrameworkCore;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Tests.Data;
 
 public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>

--- a/Authorization.Core.UI.Tests/Data/ApplicationDbContext.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationDbContext.cs
@@ -1,27 +1,26 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.EntityFrameworkCore;
 
-namespace Authorization.Core.UI.Tests.Data
+namespace Authorization.Core.UI.Tests.Data;
+
+public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>
 {
-    public class ApplicationDbContext : AuthUiContext<ApplicationUser, ApplicationRole>
+    /// <summary>
+    /// Used for testing.
+    /// </summary>
+    public ApplicationDbContext()
+    { }
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
     {
-        /// <summary>
-        /// Used for testing.
-        /// </summary>
-        public ApplicationDbContext()
-        { }
+    }
 
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder builder)
-        {
-            base.OnModelCreating(builder);
-            // Customize the ASP.NET Identity model and override the defaults if needed.
-            // For example, you can rename the ASP.NET Identity table names and more.
-            // Add your customizations after calling base.OnModelCreating(builder);
-        }
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+        // Customize the ASP.NET Identity model and override the defaults if needed.
+        // For example, you can rename the ASP.NET Identity table names and more.
+        // Add your customizations after calling base.OnModelCreating(builder);
     }
 }

--- a/Authorization.Core.UI.Tests/Data/ApplicationRole.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationRole.cs
@@ -1,9 +1,8 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI.Data;
 
-namespace Authorization.Core.UI.Tests.Data
+namespace Authorization.Core.UI.Tests.Data;
+
+public class ApplicationRole : AuthUiRole, IRequiresAuthorization
 {
-    public class ApplicationRole : AuthUiRole, IRequiresAuthorization
-    {
-    }
 }

--- a/Authorization.Core.UI.Tests/Data/ApplicationRole.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationRole.cs
@@ -1,6 +1,8 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI.Data;
 
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Tests.Data;
 
 public class ApplicationRole : AuthUiRole, IRequiresAuthorization

--- a/Authorization.Core.UI.Tests/Data/ApplicationUser.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationUser.cs
@@ -1,6 +1,9 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI.Data;
 
+#pragma warning disable CA1033 // Interface methods should be callable by child types
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Tests.Data;
 
 public class ApplicationUser : AuthUiUser, IRequiresAuthorization

--- a/Authorization.Core.UI.Tests/Data/ApplicationUser.cs
+++ b/Authorization.Core.UI.Tests/Data/ApplicationUser.cs
@@ -1,22 +1,21 @@
 ﻿using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI.Data;
 
-namespace Authorization.Core.UI.Tests.Data
+namespace Authorization.Core.UI.Tests.Data;
+
+public class ApplicationUser : AuthUiUser, IRequiresAuthorization
 {
-    public class ApplicationUser : AuthUiUser, IRequiresAuthorization
-    {
-        /// <summary>
-        /// Creates a new instance of the ApplicationUser class with default values.
-        /// </summary>
-        public ApplicationUser()
-        { }
+    /// <summary>
+    /// Creates a new instance of the ApplicationUser class with default values.
+    /// </summary>
+    public ApplicationUser()
+    { }
 
-        /// Creates a new instance of the AppUser class with the specified user name.
-        /// </summary>
-        /// <param name="userName">The user name of the new AppUser.</param>
-        public ApplicationUser(string userName) : base(userName)
-        { }
+    /// Creates a new instance of the AppUser class with the specified user name.
+    /// </summary>
+    /// <param name="userName">The user name of the new AppUser.</param>
+    public ApplicationUser(string userName) : base(userName)
+    { }
 
-        string IRequiresAuthorization.Name => !string.IsNullOrEmpty(DisplayName) ? DisplayName : Email ?? string.Empty;
-    }
+    string IRequiresAuthorization.Name => !string.IsNullOrEmpty(DisplayName) ? DisplayName : Email ?? string.Empty;
 }

--- a/Authorization.Core.UI.Tests/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests/RoleManagementTests.cs
@@ -37,7 +37,7 @@ public class NonParallelTests : TestsBase
         var model = new CreateModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
         model.OnGet();
 
-        Assert.Equal(authManager.DefinedClaims.Count, model.RoleModel.RoleClaims.Count);
+        Assert.Equal(authManager.DefinedClaims.Count, model.RoleModel.RoleClaims!.Count);
     }
 }
 
@@ -287,7 +287,7 @@ public class RoleManagementTests : TestsBase
 
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
-        Assert.Contains(model.RoleModel.Name, notifications[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications?[0].Message);
     }
 
     [Fact(DisplayName = "Edit Role [Get] returns NotFound for null ID")]
@@ -298,7 +298,7 @@ public class RoleManagementTests : TestsBase
         var logger = new FakeLogger<EditHandler>();
 
         var model = new EditModel<ApplicationUser, ApplicationRole> (authManager, repository, logger);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -351,7 +351,7 @@ public class RoleManagementTests : TestsBase
         Assert.Equal(roles[0].Id, model.RoleModel.Id);
         Assert.Equal(roles[0].Description, model.RoleModel.Description);
         Assert.Equal(roles[0].Name, model.RoleModel.Name);
-        Assert.Equal(definedClaims.Count, model.RoleModel.RoleClaims.Count);
+        Assert.Equal(definedClaims.Count, model.RoleModel.RoleClaims!.Count);
 
         var claims = model.RoleModel.RoleClaims.Where(rc => rc.IsAssigned);
         Assert.Single(claims);
@@ -382,7 +382,7 @@ public class RoleManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
-        Assert.Contains(model.RoleModel.Name, notifications[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications?[0].Message);
     }
 
     [Fact(DisplayName = "Edit Role [Post] handles DB exception")]
@@ -606,6 +606,7 @@ public class RoleManagementTests : TestsBase
 
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(model.RoleModel.Name, notifications[0].Message);
     }
 
@@ -661,7 +662,7 @@ public class RoleManagementTests : TestsBase
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
 
         var model = new DetailsModel<ApplicationUser, ApplicationRole>(authManager, repository);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -710,6 +711,7 @@ public class RoleManagementTests : TestsBase
         Assert.Equal(roles[0].Id, model.RoleModel.Id);
         Assert.Equal(roles[0].Description, model.RoleModel.Description);
         Assert.Equal(roles[0].Name, model.RoleModel.Name);
+        Assert.NotNull(model.RoleModel.RoleClaims);
         Assert.Equal(definedClaims.Count, model.RoleModel.RoleClaims.Count);
 
         var claims = model.RoleModel.RoleClaims.Where(rc => rc.IsAssigned);
@@ -725,7 +727,7 @@ public class RoleManagementTests : TestsBase
         var logger = new FakeLogger<DeleteHandler>();
 
         var model = new DeleteModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -775,6 +777,7 @@ public class RoleManagementTests : TestsBase
 
         Assert.IsType<PageResult>(result);
         Assert.Equal(role.Id, model.RoleModel.Id);
+        Assert.NotNull(model.RoleModel.RoleUsers);
         Assert.Single(model.RoleModel.RoleUsers);
         Assert.Equal(user.DisplayName, model.RoleModel.RoleUsers.First().Name);
         Assert.Equal(user.Email, model.RoleModel.RoleUsers.First().Email);
@@ -788,7 +791,7 @@ public class RoleManagementTests : TestsBase
         var logger = new FakeLogger<DeleteHandler>();
 
         var model = new DeleteModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
-        var result = await model.OnPostAsync(null);
+        var result = await model.OnPostAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -813,6 +816,7 @@ public class RoleManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(model.RoleModel.Name, notifications[0].Message);
     }
 
@@ -990,6 +994,7 @@ public class RoleManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(role.Name, notifications[0].Message);
     }
 

--- a/Authorization.Core.UI.Tests/RoleManagementTests.cs
+++ b/Authorization.Core.UI.Tests/RoleManagementTests.cs
@@ -25,7 +25,7 @@ namespace Authorization.Core.UI.Tests;
 public class NonParallelTests : TestsBase
 {
     [Fact(DisplayName = "Create Role [Get] initializes RoleClaim collection")]
-    public void RoleManagement_Test2()
+    public void Test01()
     {
         var authManager = Mock.Of<IAuthorizationManager>(am =>
             am.DefinedClaims == GetDefinedClaims()
@@ -44,7 +44,7 @@ public class NonParallelTests : TestsBase
 public class RoleManagementTests : TestsBase
 {
     [Fact(DisplayName = "RoleManagement page returns list of ApplicationRoles")]
-    public async Task RoleManagement_Test1Async()
+    public async Task Test01Async()
     {
         var roles = new List<ApplicationRole>
         {
@@ -65,7 +65,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create Role [Post] sets assigned claims")]
-    public async Task RoleManagement_Test3Async()
+    public async Task Test02Async()
     {
         ApplicationRole role = null!;
         var expectedClaims = new string[] { SysClaims.Role.Create, SysClaims.Role.Update };
@@ -108,7 +108,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create Role [Post] sets ApplicationRole properties")]
-    public async Task RoleManagement_Test4Async()
+    public async Task Test03Async()
     {
         ApplicationRole role = null!;
         var name = "TestRole";
@@ -153,7 +153,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create Role [Post] handles DB exception")]
-    public async Task RoleManagement_Test5Async()
+    public async Task Test04Async()
     {
         var dbUpdateException =
             new DbUpdateException("One or more errors occurred. (An error occurred while updating the entries. See the inner exception for details.)",
@@ -195,18 +195,18 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("Role", errors[0].ErrorMessage);
+        Assert.Contains("Role", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Create Role [Post] logs success")]
-    public async Task RoleManagement_Test6Async()   
+    public async Task Test05Async()   
     {
         ApplicationRole role = null!;
 
@@ -245,14 +245,14 @@ public class RoleManagementTests : TestsBase
         Assert.NotNull(role);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Create Role [Post] sends notification on success")]
-    public async Task RoleManagement_Test7Async()
+    public async Task Test06Async()
     {
         var principalId = Guid.NewGuid().ToString();
         var principalName = "TestUser@company.com";
@@ -287,11 +287,11 @@ public class RoleManagementTests : TestsBase
 
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
-        Assert.Contains(model.RoleModel.Name, notifications?[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications?[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit Role [Get] returns NotFound for null ID")]
-    public async Task RoleManagement_Test8Async()
+    public async Task Test07Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -304,7 +304,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Get] returns NotFound for DB not found")]
-    public async Task RoleManagement_Test9Async()
+    public async Task Test08Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>(db =>
@@ -319,7 +319,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Get] initializes RoleModel")]
-    public async Task RoleManagement_Test10Async()
+    public async Task Test09Async()
     {
         var expectedValue = "Role.List";
 
@@ -359,7 +359,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Post] sends notification for DB not found")]
-    public async Task RoleManagement_Test11Async()
+    public async Task Test10Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>(am =>
             am.DefinedClaims == GetDefinedClaims()
@@ -382,11 +382,11 @@ public class RoleManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
-        Assert.Contains(model.RoleModel.Name, notifications?[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications?[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit Role [Post] handles DB exception")]
-    public async Task RoleManagement_Test12Async()
+    public async Task Test11Async()
     {
         var dbUpdateException =
             new DbUpdateException("One or more errors occurred. (An error occurred while updating the entries. See the inner exception for details.)",
@@ -431,20 +431,20 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("Role", errors[0].ErrorMessage);
+        Assert.Contains("Role", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Edit Role [Post] sends no notification for no changes")]
-    public async Task RoleManagement_Test13Async()
+    public async Task Test12Async()
     {
         var role = new ApplicationRole { Name = "TestRole", Description = "Can do tester stuff." };
         var dbSet = new List<ApplicationRole> { role }.BuildMockDbSet();
@@ -473,7 +473,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Post] sets ApplicationRole properties")]
-    public async Task RoleManagement_Test14Async()
+    public async Task Test13Async()
     {
         var expectedName = "TestManager";
         var expectedDescription = "TestManagers do things related to testing.";
@@ -519,7 +519,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Post] updates RoleClaims")]
-    public async Task RoleManagement_Test15Async()
+    public async Task Test14Async()
     {
         var expectedClaims = new string[] { SysClaims.Role.Create, SysClaims.Role.Update };
 
@@ -568,7 +568,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Post] sends notification for update")]
-    public async Task RoleManagement_Test16Async()
+    public async Task Test15Async()
     {
         var role = new ApplicationRole { Name = "TestRole", Description = "Can do tester stuff." };
         var dbSet = new List<ApplicationRole> { role }.BuildMockDbSet();
@@ -607,11 +607,11 @@ public class RoleManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(model.RoleModel.Name, notifications[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit Role [Post] logs success")]
-    public async Task RoleManagement_Test17Async()
+    public async Task Test16Async()
     {
         var role = new ApplicationRole { Name = "TestRole", Description = "Can do tester stuff." };
         var dbSet = new List<ApplicationRole> { role }.BuildMockDbSet();
@@ -649,14 +649,14 @@ public class RoleManagementTests : TestsBase
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Display Role returns NotFound for null ID")]
-    public async Task RoleManagement_Test18Async()
+    public async Task Test17Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -668,7 +668,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Display Role returns NotFound for DB not found")]
-    public async Task RoleManagement_Test19Async()
+    public async Task Test18Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>(db =>
@@ -682,7 +682,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Display Role initializes RoleModel")]
-    public async Task RoleManagement_Test20Async()
+    public async Task Test19Async()
     {
         var expectedValue = "Role.List";
 
@@ -720,7 +720,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Get] returns NotFound for null ID")]
-    public async Task RoleManagement_Test21Async()
+    public async Task Test20Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -733,7 +733,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Get] returns NotFound for DB not found")]
-    public async Task RoleManagement_Test22Async()
+    public async Task Test21Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>(db =>
@@ -748,7 +748,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Get] initializes RoleUser collection")]
-    public async Task RoleManagement_Test23Async()
+    public async Task Test22Async()
     {
         var role = new ApplicationRole { Name = "TestManager", Description = "Does all things that are testing." };
         var roles = new List<ApplicationRole> { role }.BuildMockDbSet();
@@ -784,7 +784,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Post] returns NotFound for null ID")]
-    public async Task RoleManagement_Test24Async()
+    public async Task Test23Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -797,7 +797,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Post] sends notification for DB not found")]
-    public async Task RoleManagement_Test25Async()
+    public async Task Test24Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>(db =>
@@ -817,11 +817,11 @@ public class RoleManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(model.RoleModel.Name, notifications[0].Message);
+        Assert.Contains(model.RoleModel.Name, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete Role [Post] prevents delete of System Role")]
-    public async Task RoleManagement_Test26Async()
+    public async Task Test25Async()
     {
         var expectedMessage1 = "System Roles may not be deleted";
         var expectedMessage2 = $"delete system {nameof(ApplicationRole)}";
@@ -868,18 +868,18 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage1, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage1, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(expectedMessage2, logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedMessage2, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete Role [Post] handles DB exception")]
-    public async Task RoleManagement_Test27Async()
+    public async Task Test26Async()
     {
         var dbUpdateException =
             new DbUpdateException("One or more errors occurred. (An error occurred while updating the entries. See the inner exception for details.)",
@@ -932,20 +932,20 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("Role", errors[0].ErrorMessage);
+        Assert.Contains("Role", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Delete Role [Post] sends notification for delete")]
-    public async Task RoleManagement_Test28Async()
+    public async Task Test27Async()
     {
         var role = new ApplicationRole { Name = "TestManager", Description = "Does all things that are testing." };
 
@@ -995,11 +995,11 @@ public class RoleManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(role.Name, notifications[0].Message);
+        Assert.Contains(role.Name, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete Role [Post] logs success")]
-    public async Task RoleManagement_Test29Async()
+    public async Task Test28Async()
     {
         ApplicationRole deletedRole = null!;
 
@@ -1053,14 +1053,14 @@ public class RoleManagementTests : TestsBase
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit Role [Post] prevents update of System Role")]
-    public async Task RoleManagement_Test30Async()
+    public async Task Test29Async()
     {
         var expectedMessage1 = "You may not update the Claims assigned to a system Role";
         var expectedMessage2 = $"update the claims of system {nameof(ApplicationRole)}";
@@ -1104,18 +1104,18 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage1, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage1, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(expectedMessage2, logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedMessage2, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit Role [Post] refreshes Role cache on success")]
-    public async Task RoleManagement_Test31Async()
+    public async Task Test30Async()
     {
         var role = new ApplicationRole { Name = "TestRole", Description = "Can do tester stuff." };
         role.Claims.Add(new IdentityRoleClaim<string> { Id = 1, RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = role.Name });
@@ -1157,7 +1157,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Post] refreshes Role cache on success")]
-    public async Task RoleManagement_Test32Async()
+    public async Task Test31Async()
     {
         var role = new ApplicationRole { Name = "TestManager", Description = "Does all things that are testing." };
 
@@ -1202,7 +1202,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit Role [Get] sets IsSystemRole")]
-    public async Task RoleManagement_Test33Async()
+    public async Task Test32Async()
     {
         var role = new ApplicationRole { Id = SysUiGuids.Role.UserManager, Name = nameof(SysUiGuids.Role.UserManager) };
 
@@ -1224,7 +1224,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create Role [Post] handles failed elevation check")]
-    public async Task RoleManagement_Test34Async()
+    public async Task Test33Async()
     {
         var expectedMessage = "can not create a Role with more privileges";
         var expectedLogMessage = $"create {nameof(ApplicationRole)} with elevated privileges";
@@ -1262,17 +1262,17 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.Null(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Edit Role [Post] handles failed elevation check")]
-    public async Task RoleManagement_Test35Async()
+    public async Task Test34Async()
     {
         var expectedMessage = "can not give a Role more privileges";
         var expectedLogMessage = "elevated privileges";
@@ -1316,20 +1316,20 @@ public class RoleManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message);
-        Assert.Contains(role.Name, logger.LatestRecord.Message);
-        Assert.Contains(role.Id, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationRole), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Name, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(role.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.Null(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Delete Role [Post] removes UserClaim associated with Role")]
-    public async Task RoleManagement_Test36Async()
+    public async Task Test35Async()
     {
         var role = new ApplicationRole { Name = "TestManager", Description = "Does all things that are testing." };
 
@@ -1382,7 +1382,7 @@ public class RoleManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete Role [Post] refreshes UserClaim cache on success")]
-    public async Task RoleManagement_Test37Async()
+    public async Task Test36Async()
     {
         var role = new ApplicationRole { Name = "TestManager", Description = "Does all things that are testing." };
 

--- a/Authorization.Core.UI.Tests/TestsBase.cs
+++ b/Authorization.Core.UI.Tests/TestsBase.cs
@@ -3,6 +3,9 @@ using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI;
 using CRFricke.Authorization.Core.UI.Models;
 
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable
+#pragma warning disable CA1515 // Consider making public types internal
+
 namespace Authorization.Core.UI.Tests;
 
 public class TestsBase

--- a/Authorization.Core.UI.Tests/TestsBase.cs
+++ b/Authorization.Core.UI.Tests/TestsBase.cs
@@ -2,7 +2,6 @@
 using CRFricke.Authorization.Core;
 using CRFricke.Authorization.Core.UI;
 using CRFricke.Authorization.Core.UI.Models;
-using System.Collections.Generic;
 
 namespace Authorization.Core.UI.Tests;
 
@@ -16,18 +15,18 @@ public class TestsBase
     /// <returns>The new <see cref="RoleModel"/> object.</returns>
     internal static RoleModel CreateModelFromRole(ApplicationRole role)
     {
-        return new RoleModel { Id = role.Id, Description = role.Description, Name = role.Name };
+        return new RoleModel { Id = role.Id, Description = role.Description, Name = role.Name! };
     }
 
     /// <summary>
     /// Creates a new <see cref="UserModel"/> object using the specified <see cref="ApplicationUser"/>.
     /// </summary>
-    /// <param name="role">The <see cref="ApplicationUser"/> object to be used to initialize the <see cref="UserModel"/>.</param>
+    /// <param name="user">The <see cref="ApplicationUser"/> object to be used to initialize the <see cref="UserModel"/>.</param>
     /// <returns>The new <see cref="UserModel"/> object.</returns>
     internal static UserModel CreateModelFromUser(ApplicationUser user)
     {
         return new UserModel {
-            Id = user.Id, AccessFailedCount = user.AccessFailedCount, Email = user.Email, EmailConfirmed = user.EmailConfirmed,
+            Id = user.Id, AccessFailedCount = user.AccessFailedCount, Email = user.Email!, EmailConfirmed = user.EmailConfirmed,
             GivenName = user.GivenName, LockoutEnabled = user.LockoutEnabled, LockoutEndUtc = user.LockoutEnd,
             PhoneNumber = user.PhoneNumber, PhoneNumberConfirmed = user.PhoneNumberConfirmed, Surname = user.Surname
         };
@@ -39,11 +38,11 @@ public class TestsBase
     /// <returns>The list of defined claims.</returns>
     internal static List<string> GetDefinedClaims()
     {
-        return new List<string>
-        {
+        return
+        [
             SysClaims.Role.Create, SysClaims.Role.Delete, SysClaims.Role.List, SysClaims.Role.Read, SysClaims.Role.Update,
             SysClaims.User.Create, SysClaims.User.Delete, SysClaims.User.List, SysClaims.User.Read, SysClaims.User.Update
-        };
+        ];
     }
 
     /// <summary>
@@ -52,10 +51,10 @@ public class TestsBase
     /// <returns>The list of defined Guids.</returns>
     internal static List<string> GetDefinedGuids()
     {
-        return new List<string>
-        {
+        return
+        [
             SysGuids.Role.Administrator, SysUiGuids.Role.RoleManager, SysUiGuids.Role.UserManager,
             SysGuids.User.Administrator
-        };
+        ];
     }
 }

--- a/Authorization.Core.UI.Tests/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests/UserManagementTests.cs
@@ -16,13 +16,8 @@ using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using MockQueryable.Moq;
 using Moq;
-using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Security.Claims;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace Authorization.Core.UI.Tests;
 
@@ -110,6 +105,7 @@ public class UserManagementTests : TestsBase
         var model = new CreateModel<ApplicationUser, ApplicationRole>(authManager, userManager, repository, logger);
         _ = await model.OnGetAsync();
 
+        Assert.NotNull(model.UserModel.Roles);
         Assert.Equal(3, model.UserModel.Roles.Count);
         Assert.Equal(roles[0].Name, model.UserModel.Roles.First().Name);
         Assert.Equal(roles[2].Name, model.UserModel.Roles.Last().Name);
@@ -272,6 +268,7 @@ public class UserManagementTests : TestsBase
 
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(user.Email!, notifications[0].Message);
     }
 
@@ -336,7 +333,7 @@ public class UserManagementTests : TestsBase
         var logger = new FakeLogger<EditHandler>();
 
         var model = new EditModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -395,6 +392,7 @@ public class UserManagementTests : TestsBase
         Assert.Equal(user.PhoneNumberConfirmed, model.UserModel.PhoneNumberConfirmed);
         Assert.Equal(user.Surname, model.UserModel.Surname);
 
+        Assert.NotNull(model.UserModel.Roles);
         var claims = model.UserModel.Roles.Where(ri => ri.IsAssigned);
         Assert.Equal(expectedClaims.Length, user.Claims.Count);
         Assert.Equal(expectedClaims, user.Claims.Select(c => c.ClaimValue));
@@ -426,6 +424,7 @@ public class UserManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(model.UserModel.Email, notifications[0].Message);
     }
 
@@ -617,7 +616,7 @@ public class UserManagementTests : TestsBase
 
         var model = new EditModel<ApplicationUser, ApplicationRole>(authManager, repository, logger)
         {
-            UserModel = new UserModel { Id = user.Id, Email = user.Email },
+            UserModel = new UserModel { Id = user.Id, Email = user.Email! },
             PageContext = new PageContext { HttpContext = httpContext },
             TempData = new TestTempDataDictionary()
         };
@@ -626,6 +625,7 @@ public class UserManagementTests : TestsBase
 
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(user.Email!, notifications[0].Message);
     }
 
@@ -660,7 +660,7 @@ public class UserManagementTests : TestsBase
 
         var model = new EditModel<ApplicationUser, ApplicationRole>(authManager, repository, logger)
         {
-            UserModel = new UserModel { Id = user.Id, Email = user.Email },
+            UserModel = new UserModel { Id = user.Id, Email = user.Email! },
             PageContext = new PageContext { HttpContext = httpContext },
             TempData = new TestTempDataDictionary()
         };
@@ -683,7 +683,7 @@ public class UserManagementTests : TestsBase
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
 
         var model = new DetailsModel<ApplicationUser, ApplicationRole>(authManager, repository);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -754,6 +754,7 @@ public class UserManagementTests : TestsBase
         Assert.Equal(user.PhoneNumberConfirmed, model.UserModel.PhoneNumberConfirmed);
         Assert.Equal(user.Surname, model.UserModel.Surname);
 
+        Assert.NotNull(model.UserModel.Roles);
         var claims = model.UserModel.Roles.Where(ri => ri.IsAssigned);
         Assert.Equal(expectedClaims.Length, user.Claims.Count);
         Assert.Equal(expectedClaims, user.Claims.Select(c => c.ClaimValue));
@@ -767,7 +768,7 @@ public class UserManagementTests : TestsBase
         var logger = new FakeLogger<DeleteHandler>();
 
         var model = new DeleteModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
-        var result = await model.OnGetAsync(null);
+        var result = await model.OnGetAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -819,6 +820,7 @@ public class UserManagementTests : TestsBase
         var model = new DeleteModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
         await model.OnGetAsync(users[1].Id);
 
+        Assert.NotNull(model.UserModel.Roles);
         Assert.Equal(roles.Count, model.UserModel.Roles.Count);
 
         var claims = model.UserModel.Roles.Where(ri => ri.IsAssigned);
@@ -834,7 +836,7 @@ public class UserManagementTests : TestsBase
         var logger = new FakeLogger<DeleteHandler>();
 
         var model = new DeleteModel<ApplicationUser, ApplicationRole>(authManager, repository, logger);
-        var result = await model.OnPostAsync(null);
+        var result = await model.OnPostAsync(null!);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -864,6 +866,7 @@ public class UserManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(user.Email!, notifications[0].Message);
     }
 
@@ -965,6 +968,7 @@ public class UserManagementTests : TestsBase
         Assert.IsType<RedirectToPageResult>(result);
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
+        Assert.NotNull(notifications);
         Assert.Contains(user.Email!, notifications[0].Message);
     }
 

--- a/Authorization.Core.UI.Tests/UserManagementTests.cs
+++ b/Authorization.Core.UI.Tests/UserManagementTests.cs
@@ -60,7 +60,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "UserManagement page returns list of Users")]
-    public async Task UserManagement_Test1Async()
+    public async Task Test01Async()
     {
         var users = new List<ApplicationUser>
         {
@@ -80,7 +80,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create User [Get] initializes the RoleInfo collection")]
-    public async Task UserManagement_Test2()
+    public async Task Test02Async()
     {
         var roles = new List<ApplicationRole>
         {
@@ -112,7 +112,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create User [Post] sets assigned role claims")]
-    public async Task UserManagement_Test3Async()
+    public async Task Test03Async()
     {
         ApplicationUser user = null!;
         var expectedClaims = new string[] { SysUiGuids.Role.RoleManager };
@@ -158,7 +158,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create User [Post] handles DB exception")]
-    public async Task UserManagement_Test4Async()
+    public async Task Test04Async()
     {
         ApplicationUser user = null!;
         var dbUpdateException =
@@ -210,20 +210,20 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("User", errors[0].ErrorMessage);
+        Assert.Contains("User", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Create User [Post] sends notification on success")]
-    public async Task UserManagement_Test5Async()
+    public async Task Test05Async()
     {
         ApplicationUser user = null!;
 
@@ -269,11 +269,11 @@ public class UserManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(user.Email!, notifications[0].Message);
+        Assert.Contains(user.Email!, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Create User [Post] logs success")]
-    public async Task UserManagement_Test6Async()
+    public async Task Test06Async()
     {
         ApplicationUser user = null!;
 
@@ -319,14 +319,14 @@ public class UserManagementTests : TestsBase
         Assert.NotNull(user);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains($"created {nameof(ApplicationUser)}", logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains($"created {nameof(ApplicationUser)}", logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit User [Get] returns NotFound for null ID")]
-    public async Task UserManagement_Test7Async()
+    public async Task Test07Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -339,7 +339,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit User [Get] initializes ApplicationUserModel")]
-    public async Task UserManagement_Test8Async()
+    public async Task Test08Async()
     {
         var roles = new List<ApplicationRole>
         {
@@ -399,7 +399,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit User [Post] sends notification for DB not found")]
-    public async Task UserManagement_Test9Async()
+    public async Task Test09Async()
     {
         var users = new List<ApplicationUser>();
         var roles = new List<ApplicationRole>();
@@ -425,11 +425,11 @@ public class UserManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(model.UserModel.Email, notifications[0].Message);
+        Assert.Contains(model.UserModel.Email, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit User [Post] handles DB exception")]
-    public async Task UserManagement_Test10Async()
+    public async Task Test10Async()
     {
         var dbUpdateException =
             new DbUpdateException("One or more errors occurred. (An error occurred while updating the entries. See the inner exception for details.)",
@@ -473,20 +473,20 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("User", errors[0].ErrorMessage);
+        Assert.Contains("User", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(users[0].Id, logger.LatestRecord.Message);
-        Assert.Contains(users[0].Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(users[0].Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(users[0].Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Edit User [Post] sends no notification for no changes")]
-    public async Task UserManagement_Test11Async()
+    public async Task Test11Async()
     {
         var users = new List<ApplicationUser> { new("TestUser@company.com") };
         var roles = new List<ApplicationRole>();
@@ -514,7 +514,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit User [Post] updates User properties")]
-    public async Task UserManagement_Test12Async()
+    public async Task Test12Async()
     {
         var expectedClaims = new string[] { SysUiGuids.Role.RoleManager, SysUiGuids.Role.UserManager };
 
@@ -586,7 +586,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit User [Post] sends notification for successful update")]
-    public async Task UserManagement_Test13Async()
+    public async Task Test13Async()
     {
         var roles = new List<ApplicationRole> { };
 
@@ -626,11 +626,11 @@ public class UserManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(user.Email!, notifications[0].Message);
+        Assert.Contains(user.Email!, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit User [Post] logs successful update")]
-    public async Task UserManagement_Test14Async()
+    public async Task Test14Async()
     {
         var roles = new List<ApplicationRole> { };
 
@@ -670,14 +670,14 @@ public class UserManagementTests : TestsBase
         Assert.NotNull(user);
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Display User returns NotFound for null ID")]
-    public async Task UserManagement_Test15Async()
+    public async Task Test15Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -689,7 +689,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Display User returns NotFound for DB not found")]
-    public async Task UserManagement_Test16Async()
+    public async Task Test16Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
 
@@ -704,7 +704,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Display User initializes ApplicationUserModel")]
-    public async Task UserManagement_Test17Async()
+    public async Task Test17Async()
     {
         var roles = new List<ApplicationRole>
         {
@@ -761,7 +761,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Get] returns NotFound for null ID")]
-    public async Task UserManagement_Test18Async()
+    public async Task Test18Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -774,7 +774,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Get] returns NotFound for DB not found")]
-    public async Task UserManagement_Test19Async()
+    public async Task Test19Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
 
@@ -791,7 +791,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Get] initializes RoleInfo collection")]
-    public async Task UserManagement_Test20Async()
+    public async Task Test20Async()
     {
         var roles = GetDefinedRoles();
 
@@ -802,8 +802,8 @@ public class UserManagementTests : TestsBase
         //
         var users = new List<ApplicationUser>
         {
-            new ApplicationUser("TestUser1@company.com").SetClaims(SysGuids.Role.Administrator),
-            new ApplicationUser("TestUser2@company.com").SetClaims(expectedClaims)
+            new ApplicationUser("TestUser1@company.com").SetClaims<ApplicationUser>(SysGuids.Role.Administrator),
+            new ApplicationUser("TestUser2@company.com").SetClaims<ApplicationUser>(expectedClaims)
         };
 
         var authManager = Mock.Of<IAuthorizationManager>(am =>
@@ -829,7 +829,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Post] returns NotFound for null ID")]
-    public async Task UserManagement_Test21Async()
+    public async Task Test21Async()
     {
         var authManager = Mock.Of<IAuthorizationManager>();
         var repository = Mock.Of<IRepository<ApplicationUser, ApplicationRole>>();
@@ -842,7 +842,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Post] sends notification on DB not found")]
-    public async Task UserManagement_Test22Async()
+    public async Task Test22Async()
     {
         var user = new ApplicationUser("TestUser@company.com");
         var users = new List<ApplicationUser>([user]);
@@ -867,11 +867,11 @@ public class UserManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(user.Email!, notifications[0].Message);
+        Assert.Contains(user.Email!, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete User [Post] handles DB exception")]
-    public async Task UserManagement_Test23Async()
+    public async Task Test23Async()
     {
         var dbUpdateException =
             new DbUpdateException("One or more errors occurred. (An error occurred while updating the entries. See the inner exception for details.)",
@@ -916,20 +916,20 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains("User", errors[0].ErrorMessage);
+        Assert.Contains("User", errors[0].ErrorMessage, StringComparison.Ordinal);
         Assert.Equal(dbUpdateException.GetBaseException().Message, errors[1].ErrorMessage);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Error, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.NotNull(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Delete User [Post] sends notification for delete")]
-    public async Task UserManagement_Test24Async()
+    public async Task Test24Async()
     {
         var user = new ApplicationUser("TestUser@company.com");
 
@@ -969,11 +969,11 @@ public class UserManagementTests : TestsBase
         Assert.Single(model.TempData);
         var notifications = model.TempData.GetNotifications(model.TempData.Keys.First());
         Assert.NotNull(notifications);
-        Assert.Contains(user.Email!, notifications[0].Message);
+        Assert.Contains(user.Email!, notifications[0].Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete User [Post] logs successful delete")]
-    public async Task UserManagement_Test25Async()
+    public async Task Test25Async()
     {
         ApplicationUser deletedUser = null!;
 
@@ -1019,14 +1019,14 @@ public class UserManagementTests : TestsBase
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Information, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Delete User [Post] prevents delete of System User")]
-    public async Task UserManagement_Test26Async()
+    public async Task Test26Async()
     {
         var expectedMessage = "System accounts may not be deleted";
 
@@ -1069,19 +1069,19 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains("delete system", logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains("delete system", logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit User [Post] prevents update of System User")]
-    public async Task UserManagement_Test27Async()
+    public async Task Test27Async()
     {
         var expectedMessage = "You may not update the Roles assigned to a system User";
         var expectedLogMessage = $"update the Roles of system {nameof(ApplicationUser)}";
@@ -1137,18 +1137,18 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
     }
 
     [Fact(DisplayName = "Edit User [Post] refreshes User cache on success")]
-    public async Task UserManagement_Test28Async()
+    public async Task Test28Async()
     {
         var roles = new List<ApplicationRole>
         {
@@ -1204,7 +1204,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Delete User [Post] refreshes User cache on success")]
-    public async Task UserManagement_Test29Async()
+    public async Task Test29Async()
     {
         var user = new ApplicationUser("TestUser@company.com");
 
@@ -1247,7 +1247,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Edit User [Get] sets IsSystemUser")]
-    public async Task UserManagement_Test30Async()
+    public async Task Test30Async()
     {
         var roles = new List<ApplicationRole>();
 
@@ -1272,7 +1272,7 @@ public class UserManagementTests : TestsBase
     }
 
     [Fact(DisplayName = "Create User [Post] handles failed elevation check")]
-    public async Task UserManagement_Test31Async()
+    public async Task Test31Async()
     {
         var expectedMessage = "can not create a User with more privileges than you";
         var expectedLogMessage = $"create {nameof(ApplicationUser)} with elevated privileges";
@@ -1318,17 +1318,17 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalName, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
+        Assert.Contains(principalName, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.Null(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Edit User [Post] handles failed elevation check")]
-    public async Task UserManagement_Test32Async()
+    public async Task Test32Async()
     {
         var expectedMessage = "can not give a User more privileges than you";
         var expectedLogMessage = "elevated privileges";
@@ -1381,20 +1381,20 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principalUser.UserName!, logger.LatestRecord.Message);
-        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message);
-        Assert.Contains(user.Email!, logger.LatestRecord.Message);
-        Assert.Contains(user.Id, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
+        Assert.Contains(principalUser.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(ApplicationUser), logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Email!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(user.Id, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.Null(logger.LatestRecord.Exception);
     }
 
     [Fact(DisplayName = "Edit User [Post] handles elevation of self")]
-    public async Task UserManagement_Test33Async()
+    public async Task Test33Async()
     {
         var expectedMessage = "can not elevate your own privileges";
         var expectedLogMessage = "attempted to elevate their own privileges";
@@ -1447,12 +1447,12 @@ public class UserManagementTests : TestsBase
         Assert.False(model.ModelState.IsValid);
         Assert.Equal(2, model.ModelState.ErrorCount);
         var errors = model.ModelState[string.Empty]!.Errors;
-        Assert.Contains(expectedMessage, errors[1].ErrorMessage);
+        Assert.Contains(expectedMessage, errors[1].ErrorMessage, StringComparison.Ordinal);
 
         Assert.Equal(1, logger.Collector.Count);
         Assert.Equal(LogLevel.Warning, logger.LatestRecord.Level);
-        Assert.Contains(principal.UserName!, logger.LatestRecord.Message);
-        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message);
+        Assert.Contains(principal.UserName!, logger.LatestRecord.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedLogMessage, logger.LatestRecord.Message, StringComparison.Ordinal);
         Assert.Null(logger.LatestRecord.Exception);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Security.Claims;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
@@ -14,21 +15,40 @@ public class RoleModel
 {
     #region RoleClaim Class
 
+    /// <summary>
+    /// Represents a claim that can be assigned to a role.
+    /// </summary>
     public class RoleClaim
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoleClaim"/> class.
+        /// </summary>
         public RoleClaim()
         { }
 
+        /// <summary>
+        /// Gets or sets the claim value.
+        /// </summary>
         public string Claim { get; set; } = null!;
 
+        /// <summary>
+        /// Gets or sets the unique identifier for this role claim.
+        /// </summary>
         public int Id { get; internal set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this claim is assigned to the role.
+        /// </summary>
         [Display(Name = "Select")]
         public bool IsAssigned { get; set; }
 
+        /// <summary>
+        /// Returns a string representation of this role claim.
+        /// </summary>
+        /// <returns>A string containing the claim value and assignment status.</returns>
         public override string ToString()
         {
-            return string.Format("{0}{1}",
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}",
                 Claim, IsAssigned ? " (assigned)" : string.Empty
                 );
         }
@@ -38,35 +58,73 @@ public class RoleModel
 
     #region RoleUser class
 
+    /// <summary>
+    /// Represents a user that has been assigned to a role.
+    /// </summary>
     public class RoleUser
     {
+        /// <summary>
+        /// Gets or sets the display name of the user.
+        /// </summary>
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// Gets or sets the email address of the user.
+        /// </summary>
         public string Email { get; set; } = null!;
     }
 
     #endregion
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RoleModel"/> class.
+    /// </summary>
     public RoleModel()
     { }
 
 
+    /// <summary>
+    /// Gets or sets the unique identifier for the role.
+    /// </summary>
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the name of the role.
+    /// </summary>
     [Required]
     public string Name { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the description of the role.
+    /// </summary>
     public string? Description { get; set; }
 
-    public List<RoleClaim>? RoleClaims { get; set; }
+    /// <summary>
+    /// Gets or sets the collection of claims that can be assigned to this role.
+    /// </summary>
+    public IReadOnlyCollection<RoleClaim>? RoleClaims { get; set; }
 
-    public List<RoleUser>? RoleUsers { get; set; }
+    /// <summary>
+    /// Gets or sets the collection of users assigned to this role.
+    /// </summary>
+    public IReadOnlyCollection<RoleUser>? RoleUsers { get; set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the role's claims were updated during the last <see cref="UpdateRole"/> operation.
+    /// </summary>
     public bool ClaimsUpdated { get; private set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether this is a system-defined role.
+    /// </summary>
     public bool IsSystemRole { get; set; }
 
 
+    /// <summary>
+    /// Initializes the <see cref="RoleClaims"/> collection with all defined claims from the authorization manager.
+    /// </summary>
+    /// <param name="authManager">The authorization manager containing the defined claims.</param>
+    /// <returns>This <see cref="RoleModel"/> instance for method chaining.</returns>
     internal RoleModel InitRoleClaims(IAuthorizationManager authManager)
     {
         RoleClaims = (
@@ -77,8 +135,16 @@ public class RoleModel
         return this;
     }
 
+    /// <summary>
+    /// Initializes this <see cref="RoleModel"/> from an existing <see cref="AuthUiRole"/>.
+    /// </summary>
+    /// <param name="role">The role to initialize from.</param>
+    /// <returns>This <see cref="RoleModel"/> instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="role"/> is null.</exception>
     public virtual RoleModel InitFromRole(AuthUiRole role)
     {
+        ArgumentNullException.ThrowIfNull(role);
+
         Id = role.Id;
         Name = role.Name!;
         Description = role.Description;
@@ -86,6 +152,15 @@ public class RoleModel
         return SetAssignedClaims(role.Claims);
     }
 
+    /// <summary>
+    /// Initializes the <see cref="RoleUsers"/> collection by querying the repository for users assigned to this role.
+    /// </summary>
+    /// <typeparam name="TUser">The type of user entity.</typeparam>
+    /// <typeparam name="TRole">The type of role entity.</typeparam>
+    /// <param name="repository">The repository to query for user assignments.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains this <see cref="RoleModel"/> instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="repository"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="InitFromRole"/> has not been called before this method.</exception>
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.New(ConstructorInfo, IEnumerable<Expression>, MemberInfo[]): The Property metadata or other accessor may be trimmed.")]
     public virtual async Task<RoleModel> InitRoleUsersAsync<
         [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
@@ -94,6 +169,8 @@ public class RoleModel
         where TRole : AuthUiRole
         where TUser : AuthUiUser
     {
+        ArgumentNullException.ThrowIfNull(repository);
+
         _ = Id ?? throw new InvalidOperationException(
             $"{nameof(InitFromRole)} has not been called."
             );
@@ -103,11 +180,16 @@ public class RoleModel
             join au in repository.Users on uc.UserId equals au.Id
             where uc.ClaimType == ClaimTypes.Role && uc.ClaimValue == Id
             select new RoleUser { Name = au.DisplayName, Email = au.Email! }
-            ).ToListAsync();
+            ).ToListAsync().ConfigureAwait(false);
 
         return this;
     }
 
+    /// <summary>
+    /// Gets the collection of claim values that are currently assigned to this role.
+    /// </summary>
+    /// <returns>A collection of claim values.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="InitRoleClaims"/> has not been called.</exception>
     internal ICollection<string> GetAssignedClaims()
     {
         VerifyClaimsLoaded();
@@ -119,6 +201,11 @@ public class RoleModel
             ).ToArray();
     }
 
+    /// <summary>
+    /// Sets the assigned claims from a collection of <see cref="IdentityRoleClaim{TKey}"/>.
+    /// </summary>
+    /// <param name="roleClaims">The collection of role claims to process.</param>
+    /// <returns>This <see cref="RoleModel"/> instance for method chaining.</returns>
     private RoleModel SetAssignedClaims(ICollection<IdentityRoleClaim<string>> roleClaims)
 
     {
@@ -130,18 +217,36 @@ public class RoleModel
         return this;
     }
 
+    /// <summary>
+    /// Sets the assigned claims by marking which claims in the <see cref="RoleClaims"/> collection are assigned.
+    /// </summary>
+    /// <param name="claims">The collection of claim values to mark as assigned.</param>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="InitRoleClaims"/> has not been called.</exception>
     internal void SetAssignedClaims(IEnumerable<string> claims)
     {
         VerifyClaimsLoaded();
 
+        var claimsSet = claims.ToHashSet();
+
         foreach (var roleClaim in RoleClaims!)
         {
-            roleClaim.IsAssigned = claims.Contains(roleClaim.Claim);
+            roleClaim.IsAssigned = claimsSet.Contains(roleClaim.Claim);
         }
     }
 
+    /// <summary>
+    /// Updates the specified <see cref="AuthUiRole"/> with the values from this model.
+    /// </summary>
+    /// <param name="role">The role to update.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="role"/> is null.</exception>
+    /// <remarks>
+    /// This method updates the role's name, description, and claims. The <see cref="ClaimsUpdated"/> property
+    /// is set to indicate whether the claims were modified.
+    /// </remarks>
     public virtual void UpdateRole(AuthUiRole role)
     {
+        ArgumentNullException.ThrowIfNull(role);
+
         var normalizer = new UpperInvariantLookupNormalizer();
 
         if (Description != role.Description)
@@ -158,6 +263,10 @@ public class RoleModel
         ClaimsUpdated = role.UpdateClaims(GetAssignedClaims());
     }
 
+    /// <summary>
+    /// Verifies that the <see cref="RoleClaims"/> collection has been initialized.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="InitRoleClaims"/> has not been called.</exception>
     private void VerifyClaimsLoaded()
     {
         _ = RoleClaims ?? throw new InvalidOperationException(
@@ -166,9 +275,9 @@ public class RoleModel
     }
 
     /// <summary>
-    /// Returns a representation of this <see cref="RoleModel"/>.
+    /// Returns a string representation of this <see cref="RoleModel"/>.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The role name.</returns>
     public override string ToString()
     {
         return Name;

--- a/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/RoleModel.cs
@@ -1,13 +1,12 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Security.Claims;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+#pragma warning disable CA1034 // Nested types should not be visible
 
 namespace CRFricke.Authorization.Core.UI.Models;
 
@@ -20,7 +19,7 @@ public class RoleModel
         public RoleClaim()
         { }
 
-        public string Claim { get; set; }
+        public string Claim { get; set; } = null!;
 
         public int Id { get; internal set; }
 
@@ -41,9 +40,9 @@ public class RoleModel
 
     public class RoleUser
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public string Email { get; set; }
+        public string Email { get; set; } = null!;
     }
 
     #endregion
@@ -52,16 +51,16 @@ public class RoleModel
     { }
 
 
-    public string Id { get; set; }
+    public string? Id { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
-    public List<RoleClaim> RoleClaims { get; set; }
+    public List<RoleClaim>? RoleClaims { get; set; }
 
-    public List<RoleUser> RoleUsers { get; set; }
+    public List<RoleUser>? RoleUsers { get; set; }
 
     public bool ClaimsUpdated { get; private set; }
 
@@ -81,7 +80,7 @@ public class RoleModel
     public virtual RoleModel InitFromRole(AuthUiRole role)
     {
         Id = role.Id;
-        Name = role.Name;
+        Name = role.Name!;
         Description = role.Description;
 
         return SetAssignedClaims(role.Claims);
@@ -103,7 +102,7 @@ public class RoleModel
             from uc in repository.UserClaims
             join au in repository.Users on uc.UserId equals au.Id
             where uc.ClaimType == ClaimTypes.Role && uc.ClaimValue == Id
-            select new RoleUser { Name = au.DisplayName, Email = au.Email }
+            select new RoleUser { Name = au.DisplayName, Email = au.Email! }
             ).ToListAsync();
 
         return this;
@@ -135,7 +134,7 @@ public class RoleModel
     {
         VerifyClaimsLoaded();
 
-        foreach (var roleClaim in RoleClaims)
+        foreach (var roleClaim in RoleClaims!)
         {
             roleClaim.IsAssigned = claims.Contains(roleClaim.Claim);
         }

--- a/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
@@ -1,235 +1,233 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core.UI.Models
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+#pragma warning disable CA1034 // Nested types should not be visible
+
+namespace CRFricke.Authorization.Core.UI.Models;
+
+public class UserModel
 {
-    public class UserModel
+    public UserModel() { }
+
+    #region RoleInfo Class
+
+    public class RoleInfo
     {
-        public UserModel() { }
+        public RoleInfo()
+        { }
 
-        #region RoleInfo Class
+        public string Id { get; set; } = null!;
 
-        public class RoleInfo
-        {
-            public RoleInfo()
-            { }
+        public string? Name { get; set; }
 
-            public string Id { get; set; }
+        public string? Description { get; set; }
 
-            public string Name { get; set; }
-
-            public string Description { get; set; }
-
-            [Display(Name = "Select")]
-            public bool IsAssigned { get; set; }
-
-            public override string ToString()
-            {
-                return string.Format("{0}{1}",
-                    Name, IsAssigned ? " (assigned)" : string.Empty
-                    );
-            }
-        }
-
-        #endregion
-
-        public string Id { get; set; }
-
-        [Display(Name = "Failed Logins")]
-        public int AccessFailedCount { get; set; }
-
-        [Required]
-        [EmailAddress]
-        public string Email { get; set; }
-
-        [Display(Name = "Email Confirmed")]
-        public bool EmailConfirmed { get; set; } = true;
-
-        [Display(Name = "Lockout Enabled")]
-        public bool LockoutEnabled { get; set; } = true;
-
-        [Display(Name = "Lockout Ends On (UTC)")]
-        [DataType(DataType.DateTime)]
-        [DisplayFormat(DataFormatString = "{0:M/d/yyyy h:m:ss tt K}")]
-        public DateTimeOffset? LockoutEndUtc { get; set; }
-
-        [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
-        [DataType(DataType.Password)]
-        [Display(Name = "Password")]
-        public string Password { get; set; }
-
-        [DataType(DataType.Password)]
-        [Display(Name = "Confirm password")]
-        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Referenced property is a string.")]
-        public string ConfirmPassword { get; set; }
-
-        [Phone]
-        [Display(Name = "Phone Number")]
-        public string PhoneNumber { get; set; }
-
-        [Display(Name = "Phone Number Confirmed")]
-        public bool PhoneNumberConfirmed { get; set; }
-
-        [Display(Name = "First Name")]
-        public string GivenName { get; set; }
-
-        [Display(Name = "Last Name")]
-        public string Surname { get; set; }
-
-        public ICollection<RoleInfo> Roles { get; private set; }
-
-        public bool ClaimsUpdated { get; private set; }
-
-        public bool IsSystemUser { get; set; }
+        [Display(Name = "Select")]
+        public bool IsAssigned { get; set; }
 
         public override string ToString()
         {
-            return Email;
-        }
-
-        /// <summary>
-        /// Initializes this <see cref="UserModel"/> object using the specified <typeparamref name="TUser"/> class instance.
-        /// </summary>
-        /// <typeparam name="TUser">A <see cref="Type"/> that extends <see cref="AppUserBase"/>.</typeparam>
-        /// <param name="user">
-        /// The <typeparamref name="TUser"/> class instance to be used to initialize this <see cref="UserModel"/> object.
-        /// </param>
-        /// <returns>The initialized <see cref="UserModel"/> object.</returns>
-        public virtual UserModel InitFromUser<TUser>(TUser user) where TUser : AuthUiUser
-        {
-            Id = user.Id;
-            AccessFailedCount = user.AccessFailedCount;
-            Email = user.Email;
-            EmailConfirmed = user.EmailConfirmed;
-            LockoutEnabled = user.LockoutEnabled;
-            LockoutEndUtc = user.LockoutEnd;
-            Password = "Only used in create mode";
-            ConfirmPassword = Password;
-            PhoneNumber = user.PhoneNumber;
-            PhoneNumberConfirmed = user.PhoneNumberConfirmed;
-            GivenName = user.GivenName;
-            Surname = user.Surname;
-
-            SetAssignedClaims(user.Claims);
-
-            return this;
-        }
-
-        [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
-        public virtual async Task<UserModel> InitRoleInfoAsync<
-            [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser, 
-            [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole
-            >(IRepository<TUser, TRole> repository)
-            where TRole : AuthUiRole
-            where TUser : AuthUiUser
-        {
-            Roles = await (
-                from ar in repository.Roles
-                select new RoleInfo { Description = ar.Description, Id = ar.Id, IsAssigned = false, Name = ar.Name }
-                ).ToArrayAsync();
-
-            return this;
-        }
-
-        internal ICollection<string> GetAssignedClaims()
-        {
-            VerifyRolesLoaded();
-
-            return (
-                from role in Roles
-                where role.IsAssigned
-                select role.Id
-                ).ToArray();
-        }
-
-        private void SetAssignedClaims(ICollection<IdentityUserClaim<string>> claims)
-        {
-            SetAssignedClaims(
-                from claim in claims
-                select claim.ClaimValue
+            return string.Format("{0}{1}",
+                Name, IsAssigned ? " (assigned)" : string.Empty
                 );
         }
+    }
 
-        internal void SetAssignedClaims(IEnumerable<string> roles)
+    #endregion
+
+    public string? Id { get; set; }
+
+    [Display(Name = "Failed Logins")]
+    public int AccessFailedCount { get; set; }
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } =null!;
+
+    [Display(Name = "Email Confirmed")]
+    public bool EmailConfirmed { get; set; } = true;
+
+    [Display(Name = "Lockout Enabled")]
+    public bool LockoutEnabled { get; set; } = true;
+
+    [Display(Name = "Lockout Ends On (UTC)")]
+    [DataType(DataType.DateTime)]
+    [DisplayFormat(DataFormatString = "{0:M/d/yyyy h:m:ss tt K}")]
+    public DateTimeOffset? LockoutEndUtc { get; set; }
+
+    [Required]
+    [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+    [DataType(DataType.Password)]
+    [Display(Name = "Password")]
+    public string Password { get; set; } = null!;
+
+    [DataType(DataType.Password)]
+    [Display(Name = "Confirm password")]
+    [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Referenced property is a string.")]
+    public string? ConfirmPassword { get; set; }
+
+    [Phone]
+    [Display(Name = "Phone Number")]
+    public string? PhoneNumber { get; set; }
+
+    [Display(Name = "Phone Number Confirmed")]
+    public bool PhoneNumberConfirmed { get; set; }
+
+    [Display(Name = "First Name")]
+    public string? GivenName { get; set; }
+
+    [Display(Name = "Last Name")]
+    public string? Surname { get; set; }
+
+    public ICollection<RoleInfo>? Roles { get; private set; }
+
+    public bool ClaimsUpdated { get; private set; }
+
+    public bool IsSystemUser { get; set; }
+
+    public override string ToString()
+    {
+        return Email;
+    }
+
+    /// <summary>
+    /// Initializes this <see cref="UserModel"/> object using the specified <typeparamref name="TUser"/> class instance.
+    /// </summary>
+    /// <typeparam name="TUser">A <see cref="Type"/> that extends <see cref="AppUserBase"/>.</typeparam>
+    /// <param name="user">
+    /// The <typeparamref name="TUser"/> class instance to be used to initialize this <see cref="UserModel"/> object.
+    /// </param>
+    /// <returns>The initialized <see cref="UserModel"/> object.</returns>
+    public virtual UserModel InitFromUser<TUser>(TUser user) where TUser : AuthUiUser
+    {
+        Id = user.Id;
+        AccessFailedCount = user.AccessFailedCount;
+        Email = user.Email!;
+        EmailConfirmed = user.EmailConfirmed;
+        LockoutEnabled = user.LockoutEnabled;
+        LockoutEndUtc = user.LockoutEnd;
+        Password = "Only used in create mode";
+        ConfirmPassword = Password;
+        PhoneNumber = user.PhoneNumber;
+        PhoneNumberConfirmed = user.PhoneNumberConfirmed;
+        GivenName = user.GivenName;
+        Surname = user.Surname;
+
+        SetAssignedClaims(user.Claims);
+
+        return this;
+    }
+
+    [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
+    public virtual async Task<UserModel> InitRoleInfoAsync<
+        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser, 
+        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole
+        >(IRepository<TUser, TRole> repository)
+        where TRole : AuthUiRole
+        where TUser : AuthUiUser
+    {
+        Roles = await (
+            from ar in repository.Roles
+            select new RoleInfo { Description = ar.Description, Id = ar.Id, IsAssigned = false, Name = ar.Name }
+            ).ToArrayAsync();
+
+        return this;
+    }
+
+    internal ICollection<string> GetAssignedClaims()
+    {
+        VerifyRolesLoaded();
+
+        return (
+            from role in Roles
+            where role.IsAssigned
+            select role.Id
+            ).ToArray();
+    }
+
+    private void SetAssignedClaims(ICollection<IdentityUserClaim<string>> claims)
+    {
+        SetAssignedClaims(
+            from claim in claims
+            select claim.ClaimValue
+            );
+    }
+
+    internal void SetAssignedClaims(IEnumerable<string> roles)
+    {
+        VerifyRolesLoaded();
+
+        foreach (var role in Roles!)
         {
-            VerifyRolesLoaded();
+            role.IsAssigned = roles.Contains(role.Id);
+        }
+    }
 
-            foreach (var role in Roles)
-            {
-                role.IsAssigned = roles.Contains(role.Id);
-            }
+    public virtual void UpdateUser<TUser>(TUser user) where TUser : AuthUiUser
+    {
+        var normalizer = new UpperInvariantLookupNormalizer();
+
+        if (AccessFailedCount != user.AccessFailedCount)
+        {
+            user.AccessFailedCount = AccessFailedCount;
         }
 
-        public virtual void UpdateUser<TUser>(TUser user) where TUser : AuthUiUser
+        if (Email != user.Email)
         {
-            var normalizer = new UpperInvariantLookupNormalizer();
+            user.Email = Email;
+            user.NormalizedEmail = normalizer.NormalizeEmail(Email);
 
-            if (AccessFailedCount != user.AccessFailedCount)
-            {
-                user.AccessFailedCount = AccessFailedCount;
-            }
-
-            if (Email != user.Email)
-            {
-                user.Email = Email;
-                user.NormalizedEmail = normalizer.NormalizeEmail(Email);
-
-                user.UserName = Email;
-                user.NormalizedUserName = user.NormalizedEmail;
-            }
-
-            if (EmailConfirmed != user.EmailConfirmed)
-            {
-                user.EmailConfirmed = EmailConfirmed;
-            }
-
-            if (GivenName != user.GivenName)
-            {
-                user.GivenName = GivenName;
-            }
-
-            if (LockoutEnabled != user.LockoutEnabled)
-            {
-                user.LockoutEnabled = LockoutEnabled;
-            }
-
-            if (LockoutEndUtc != user.LockoutEnd)
-            {
-                user.LockoutEnd = LockoutEndUtc;
-            }
-
-            if (PhoneNumber != user.PhoneNumber)
-            {
-                user.PhoneNumber = PhoneNumber;
-            }
-
-            if (PhoneNumberConfirmed != user.PhoneNumberConfirmed)
-            {
-                user.PhoneNumberConfirmed = PhoneNumberConfirmed;
-            }
-
-            if (Surname != user.Surname)
-            {
-                user.Surname = Surname;
-            }
-
-            ClaimsUpdated = user.UpdateClaims(GetAssignedClaims());
+            user.UserName = Email;
+            user.NormalizedUserName = user.NormalizedEmail;
         }
 
-        private void VerifyRolesLoaded()
+        if (EmailConfirmed != user.EmailConfirmed)
         {
-            _ = Roles ?? throw new InvalidOperationException(
-                $"{nameof(InitRoleInfoAsync)} has not been called yet."
-                );
+            user.EmailConfirmed = EmailConfirmed;
         }
+
+        if (GivenName != user.GivenName)
+        {
+            user.GivenName = GivenName;
+        }
+
+        if (LockoutEnabled != user.LockoutEnabled)
+        {
+            user.LockoutEnabled = LockoutEnabled;
+        }
+
+        if (LockoutEndUtc != user.LockoutEnd)
+        {
+            user.LockoutEnd = LockoutEndUtc;
+        }
+
+        if (PhoneNumber != user.PhoneNumber)
+        {
+            user.PhoneNumber = PhoneNumber;
+        }
+
+        if (PhoneNumberConfirmed != user.PhoneNumberConfirmed)
+        {
+            user.PhoneNumberConfirmed = PhoneNumberConfirmed;
+        }
+
+        if (Surname != user.Surname)
+        {
+            user.Surname = Surname;
+        }
+
+        ClaimsUpdated = user.UpdateClaims(GetAssignedClaims());
+    }
+
+    private void VerifyRolesLoaded()
+    {
+        _ = Roles ?? throw new InvalidOperationException(
+            $"{nameof(InitRoleInfoAsync)} has not been called yet."
+            );
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Models/UserModel.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 #pragma warning disable CA1034 // Nested types should not be visible
@@ -31,7 +32,7 @@ public class UserModel
 
         public override string ToString()
         {
-            return string.Format("{0}{1}",
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}",
                 Name, IsAssigned ? " (assigned)" : string.Empty
                 );
         }
@@ -105,6 +106,8 @@ public class UserModel
     /// <returns>The initialized <see cref="UserModel"/> object.</returns>
     public virtual UserModel InitFromUser<TUser>(TUser user) where TUser : AuthUiUser
     {
+        ArgumentNullException.ThrowIfNull(user);
+
         Id = user.Id;
         AccessFailedCount = user.AccessFailedCount;
         Email = user.Email!;
@@ -131,10 +134,12 @@ public class UserModel
         where TRole : AuthUiRole
         where TUser : AuthUiUser
     {
+        ArgumentNullException.ThrowIfNull(repository);
+
         Roles = await (
             from ar in repository.Roles
             select new RoleInfo { Description = ar.Description, Id = ar.Id, IsAssigned = false, Name = ar.Name }
-            ).ToArrayAsync();
+            ).ToArrayAsync().ConfigureAwait(false);
 
         return this;
     }
@@ -162,14 +167,18 @@ public class UserModel
     {
         VerifyRolesLoaded();
 
+        var rolesArray = roles.ToHashSet();
+
         foreach (var role in Roles!)
         {
-            role.IsAssigned = roles.Contains(role.Id);
+            role.IsAssigned = rolesArray.Contains(role.Id);
         }
     }
 
     public virtual void UpdateUser<TUser>(TUser user) where TUser : AuthUiUser
     {
+        ArgumentNullException.ThrowIfNull(user);
+
         var normalizer = new UpperInvariantLookupNormalizer();
 
         if (AccessFailedCount != user.AccessFailedCount)

--- a/Authorization.Core.UI/Areas/Authorization/Pages/ModelBase.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/ModelBase.cs
@@ -3,38 +3,39 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using System;
 using System.Collections.Generic;
 
-namespace CRFricke.Authorization.Core.UI.Pages
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace CRFricke.Authorization.Core.UI.Pages;
+
+public class ModelBase : PageModel
 {
-    public class ModelBase : PageModel
+    /// <summary>
+    /// Sends a notification message of the specified <see cref="Severity"/> to the specified page.
+    /// </summary>
+    /// <param name="toType">The <see cref="Type"/> of the page to receive the message.</param>
+    /// <param name="severity">The severity of the message.</param>
+    /// <param name="message">The message to be sent.</param>
+    internal void SendNotification(Type toType, Severity severity, string message)
     {
-        /// <summary>
-        /// Sends a notification message of the specified <see cref="Severity"/> to the specified page.
-        /// </summary>
-        /// <param name="toType">The <see cref="Type"/> of the page to receive the message.</param>
-        /// <param name="severity">The severity of the message.</param>
-        /// <param name="message">The message to be sent.</param>
-        internal void SendNotification(Type toType, Severity severity, string message)
-        {
-            var notifications = TempData.GetNotifications(toType.FullName) ?? new List<Notification>();
-            notifications.Add(new Notification { Severity = severity, Message = message });
+        var notifications = TempData.GetNotifications(toType.FullName!) ?? [];
+        notifications.Add(new Notification { Severity = severity, Message = message });
 
-            TempData.SetNotifications(toType.FullName, notifications);
-        }
-
-        ///<inheritdoc/>
-        public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
-        {
-            var pageType = GetType();
-            if (pageType.IsGenericType)
-            {
-                pageType = pageType.BaseType;
-            }
-
-            Notifications = TempData.GetNotifications(pageType.FullName);
-
-            base.OnPageHandlerExecuting(context);
-        }
-
-        public List<Notification> Notifications { get; private set; }
+        TempData.SetNotifications(toType.FullName!, notifications);
     }
+
+    ///<inheritdoc/>
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var pageType = GetType();
+        if (pageType.IsGenericType)
+        {
+            pageType = pageType.BaseType!;
+        }
+
+        Notifications = TempData.GetNotifications(pageType.FullName!);
+
+        base.OnPageHandlerExecuting(context);
+    }
+
+    public List<Notification>? Notifications { get; private set; }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/ModelBase.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/ModelBase.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
-using System.Collections.Generic;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
@@ -37,5 +35,5 @@ public class ModelBase : PageModel
         base.OnPageHandlerExecuting(context);
     }
 
-    public List<Notification>? Notifications { get; private set; }
+    public IList<Notification>? Notifications { get; private set; }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Notification.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Notification.cs
@@ -1,34 +1,35 @@
-﻿namespace CRFricke.Authorization.Core.UI.Pages
+﻿#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace CRFricke.Authorization.Core.UI.Pages;
+
+/// <summary>
+/// The severity associated with a <see cref="Notification"/>.
+/// </summary>
+public enum Severity
 {
     /// <summary>
-    /// The severity associated with a <see cref="Notification"/>.
+    /// It is a normal message.
     /// </summary>
-    public enum Severity
-    {
-        /// <summary>
-        /// It is a normal message.
-        /// </summary>
-        Normal,
-
-        /// <summary>
-        /// It is a high severity message.
-        /// </summary>
-        High
-    }
+    Normal,
 
     /// <summary>
-    /// A notification message to be displayed on another Razor page.
+    /// It is a high severity message.
     /// </summary>
-    public class Notification
-    {
-        /// <summary>
-        /// The <see cref="Severity"/> of the message.
-        /// </summary>
-        public Severity Severity { get; set; }
+    High
+}
 
-        /// <summary>
-        /// The message to be displayed on the other Razor page.
-        /// </summary>
-        public string Message { get; set; }
-    }
+/// <summary>
+/// A notification message to be displayed on another Razor page.
+/// </summary>
+public class Notification
+{
+    /// <summary>
+    /// The <see cref="Severity"/> of the message.
+    /// </summary>
+    public Severity Severity { get; set; }
+
+    /// <summary>
+    /// The message to be displayed on the other Razor page.
+    /// </summary>
+    public string Message { get; set; } = null!;
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 
@@ -68,14 +68,14 @@ internal class CreateHandler<
     /// <item>Thrown if no <see cref="IRepository{TUser, TRole}"/> implementation can be found by the the <see cref="IServiceProvider"/>.</item>
     /// </list>
     /// </exception>
-    public async Task<IActionResult> OnPostAsync(RoleModel roleModel, ModelBase modelBase, string hfClaimList)
+    public async Task<IActionResult> OnPostAsync(RoleModel roleModel, ModelBase modelBase, string? hfClaimList)
     {
         var modelState = modelBase.ModelState;
         var principal = modelBase.User;
 
         roleModel.InitRoleClaims(_authManager)
             .SetAssignedClaims(
-                hfClaimList?.Split(',') ?? Array.Empty<string>()
+                hfClaimList?.Split(',') ?? []
                 );
 
         if (!modelState.IsValid)
@@ -93,7 +93,7 @@ internal class CreateHandler<
 
             _logger.LogWarning(
                 "'{PrincipalEmail}' attempted to create {RoleType} with elevated privileges.",
-                principal.Identity.Name, typeof(TRole).Name
+                principal.Identity!.Name, typeof(TRole).Name
                 );
 
             return modelBase.Page();
@@ -111,7 +111,7 @@ internal class CreateHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return modelBase.Page();
@@ -124,7 +124,7 @@ internal class CreateHandler<
 
         _logger.LogInformation(
             "'{PrincipalEmail}' created {RoleType} '{RoleName}' (ID: {RoleId}).",
-            principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+            principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
@@ -92,9 +92,9 @@ internal class CreateHandler<
             modelState.AddModelError(string.Empty, "Can not create Role:");
             modelState.AddModelError(string.Empty, "You can not create a Role with more privileges than you have.");
 
-            _logger.LogWarning(
-                "'{PrincipalEmail}' attempted to create {RoleType} with elevated privileges.",
-                principal.Identity!.Name, typeof(TRole).Name
+            _logger.LogAttemptedElevatedPrivilegeRoleCreation(
+                principal.Identity!.Name,
+                typeof(TRole).Name
                 );
 
             return modelBase.Page();
@@ -111,9 +111,12 @@ internal class CreateHandler<
             modelState.AddModelError(string.Empty, "Could not create Role:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not create {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+            _logger.LogRoleCreationFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
 
             return modelBase.Page();
@@ -125,9 +128,11 @@ internal class CreateHandler<
             $"Role '{role.Name}' successfully created."
             );
 
-        _logger.LogInformation(
-            "'{PrincipalEmail}' created {RoleType} '{RoleName}' (ID: {RoleId}).",
-            principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+        _logger.LogRoleCreated(
+            principal.Identity!.Name,
+            typeof(TRole).Name,
+            role.Name,
+            role.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/CreateHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA1716 // Identifiers should not match keywords
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
@@ -85,7 +86,7 @@ internal class CreateHandler<
 
         var role = CreateRole(roleModel);
 
-        var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.Create));
+        var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.Create)).ConfigureAwait(false);
         if (!result.Succeeded)
         {
             modelState.AddModelError(string.Empty, "Can not create Role:");
@@ -99,10 +100,11 @@ internal class CreateHandler<
             return modelBase.Page();
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
             _repository.Roles.Add(role);
-            await _repository.SaveChangesAsync();
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -116,6 +118,7 @@ internal class CreateHandler<
 
             return modelBase.Page();
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         modelBase.SendNotification(
             _notificationReceiver, Severity.Normal,
@@ -140,7 +143,7 @@ internal class CreateHandler<
             Description = model.Description,
             Name = model.Name,
             NormalizedName = normalizer.NormalizeName(model.Name)
-        }.SetClaims(model.GetAssignedClaims());
+        }.SetClaims<TRole>(model.GetAssignedClaims());
 
         return role;
     }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
@@ -3,11 +3,10 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Security.Claims;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 
@@ -118,7 +117,7 @@ internal class DeleteHandler<
 
             _logger.LogWarning(
                 "'{PrincipalEmail}' attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             await roleModel.InitRoleClaims(_authManager)
@@ -148,7 +147,7 @@ internal class DeleteHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             await roleModel.InitRoleClaims(_authManager)
@@ -174,7 +173,7 @@ internal class DeleteHandler<
 
         _logger.LogInformation(
             "'{PrincipalEmail}' deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
-            principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+            principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
@@ -60,7 +60,7 @@ internal class DeleteHandler<
         var role = await _repository.Roles
             .Include(ar => ar.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (role == null)
         {
@@ -72,7 +72,7 @@ internal class DeleteHandler<
         await roleModel
             .InitRoleClaims(_authManager)
             .InitFromRole(role)
-            .InitRoleUsersAsync(_repository);
+            .InitRoleUsersAsync(_repository).ConfigureAwait(false);
 
         return modelBase.Page();
     }
@@ -95,7 +95,7 @@ internal class DeleteHandler<
         var modelState = modelBase.ModelState;
         var principal = modelBase.User;
 
-        var role = await _repository.Roles.FindAsync(id);
+        var role = await _repository.Roles.FindAsync(id).ConfigureAwait(false);
         if (role == null)
         {
             modelBase.SendNotification(
@@ -109,7 +109,7 @@ internal class DeleteHandler<
         // Don't care about ModelState on Delete.
         modelState.Clear();
 
-        var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.Delete));
+        var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.Delete)).ConfigureAwait(false);
         if (!result.Succeeded)
         {
             modelState.AddModelError(string.Empty, "Can not delete Role:");
@@ -122,7 +122,7 @@ internal class DeleteHandler<
 
             await roleModel.InitRoleClaims(_authManager)
                 .InitFromRole(role)
-                .InitRoleUsersAsync(_repository);
+                .InitRoleUsersAsync(_repository).ConfigureAwait(false);
 
             return modelBase.Page();
         }
@@ -132,13 +132,14 @@ internal class DeleteHandler<
             join au in _repository.Users on uc.UserId equals au.Id
             where uc.ClaimType == ClaimTypes.Role && uc.ClaimValue == role.Name
             select uc
-            ).ToArrayAsync();
+            ).ToArrayAsync().ConfigureAwait(false);
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
             _repository.UserClaims.RemoveRange(userClaims);
             _repository.Roles.Remove(role);
-            await _repository.SaveChangesAsync();
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -152,10 +153,11 @@ internal class DeleteHandler<
 
             await roleModel.InitRoleClaims(_authManager)
                 .InitFromRole(role)
-                .InitRoleUsersAsync(_repository);
+                .InitRoleUsersAsync(_repository).ConfigureAwait(false);
 
             return modelBase.Page();
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         // Remove any users that were assigned this role from the UserClaim cache
         foreach (var claim in userClaims)

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DeleteHandler.cs
@@ -115,9 +115,11 @@ internal class DeleteHandler<
             modelState.AddModelError(string.Empty, "Can not delete Role:");
             modelState.AddModelError(string.Empty, "System Roles may not be deleted.");
 
-            _logger.LogWarning(
-                "'{PrincipalEmail}' attempted to delete system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+            _logger.LogAttemptedSystemRoleDeletion(
+                principal.Identity!.Name,
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
 
             await roleModel.InitRoleClaims(_authManager)
@@ -146,9 +148,12 @@ internal class DeleteHandler<
             modelState.AddModelError(string.Empty, "Could not delete Role:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not delete {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+            _logger.LogRoleDeletionFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
 
             await roleModel.InitRoleClaims(_authManager)
@@ -173,9 +178,11 @@ internal class DeleteHandler<
             $"Role '{role.Name}' successfully deleted."
             );
 
-        _logger.LogInformation(
-            "'{PrincipalEmail}' deleted {RoleType} '{RoleName}' (ID: {RoleId}).",
-            principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+        _logger.LogRoleDeleted(
+            principal.Identity!.Name,
+            typeof(TRole).Name,
+            role.Name,
+            role.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DetailsHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DetailsHandler.cs
@@ -2,9 +2,9 @@
 using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DetailsHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/DetailsHandler.cs
@@ -47,7 +47,7 @@ internal class DetailsHandler<
         var role = await _repository.Roles
             .Include(ar => ar.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (role == null)
         {

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
@@ -127,17 +127,21 @@ internal class EditHandler<
                 {
                     var message = "You may not update the Claims assigned to a system Role.";
                     modelState.AddModelError(string.Empty, message);
-                    _logger.LogWarning(
-                        "'{PrincipalEmail}' attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                        principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+                    _logger.LogAttemptedSystemRoleClaimsUpdate(
+                        principal.Identity!.Name,
+                        typeof(TRole).Name,
+                        role.Name,
+                        role.Id
                         );
                     return modelBase.Page();
                 }
 
                 modelState.AddModelError(string.Empty, "You can not give a Role more privileges than you have.");
-                _logger.LogWarning(
-                    "'{PrincipalEmail}' attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
-                    principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+                _logger.LogAttemptedElevatedPrivilegeRoleUpdate(
+                    principal.Identity!.Name,
+                    typeof(TRole).Name,
+                    role.Name,
+                    role.Id
                     );
                 return modelBase.Page();
             }
@@ -153,9 +157,12 @@ internal class EditHandler<
             modelState.AddModelError(string.Empty, "Could not update Role:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+            _logger.LogRoleUpdateFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
 
             return modelBase.Page();
@@ -174,9 +181,11 @@ internal class EditHandler<
                 $"Role '{role.Name}' was successfully updated."
                 );
 
-            _logger.LogInformation(
-                "'{PrincipalEmail}' updated {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
+            _logger.LogRoleUpdated(
+                principal.Identity!.Name,
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
@@ -58,7 +58,7 @@ internal class EditHandler<
         var role = await _repository.Roles
             .Include(ar => ar.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (role == null)
         {
@@ -101,7 +101,7 @@ internal class EditHandler<
 
         var role = await _repository.Roles
             .Include(ar => ar.Claims)
-            .FirstOrDefaultAsync(m => m.Id == roleModel.Id);
+            .FirstOrDefaultAsync(m => m.Id == roleModel.Id).ConfigureAwait(false);
 
         if (role == null)
         {
@@ -118,7 +118,7 @@ internal class EditHandler<
 
         if (roleModel.ClaimsUpdated)
         {
-            var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.UpdateClaims));
+            var result = await _authManager.AuthorizeAsync(principal, role, new AppClaimRequirement(SysClaims.Role.UpdateClaims)).ConfigureAwait(false);
             if (!result.Succeeded)
             {
                 modelState.AddModelError(string.Empty, "Can not update Role:");
@@ -143,9 +143,10 @@ internal class EditHandler<
             }
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            rowsUpdated = await _repository.SaveChangesAsync();
+            rowsUpdated = await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -159,6 +160,7 @@ internal class EditHandler<
 
             return modelBase.Page();
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         if (rowsUpdated > 0)
         {

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/EditHandler.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 
@@ -91,7 +91,7 @@ internal class EditHandler<
 
         roleModel.InitRoleClaims(_authManager)
             .SetAssignedClaims(
-                hfClaimList?.Split(',') ?? Array.Empty<string>()
+                hfClaimList?.Split(',') ?? []
                 );
 
         if (!modelState.IsValid)
@@ -123,13 +123,13 @@ internal class EditHandler<
             {
                 modelState.AddModelError(string.Empty, "Can not update Role:");
 
-                if (result.Failure.FailureReason == AuthorizationFailure.Reason.SystemObject)
+                if (result.Failure!.FailureReason == AuthorizationFailure.Reason.SystemObject)
                 {
                     var message = "You may not update the Claims assigned to a system Role.";
                     modelState.AddModelError(string.Empty, message);
                     _logger.LogWarning(
                         "'{PrincipalEmail}' attempted to update the claims of system {RoleType} '{RoleName}' (ID: {RoleId}).",
-                        principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                        principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                         );
                     return modelBase.Page();
                 }
@@ -137,7 +137,7 @@ internal class EditHandler<
                 modelState.AddModelError(string.Empty, "You can not give a Role more privileges than you have.");
                 _logger.LogWarning(
                     "'{PrincipalEmail}' attempted to give {RoleType} '{RoleName}' (ID: {RoleId}) elevated privileges.",
-                    principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                    principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                     );
                 return modelBase.Page();
             }
@@ -154,7 +154,7 @@ internal class EditHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not update {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                 );
 
             return modelBase.Page();
@@ -174,7 +174,7 @@ internal class EditHandler<
 
             _logger.LogInformation(
                 "'{PrincipalEmail}' updated {RoleType} '{RoleName}' (ID: {RoleId}).",
-                principal.Identity.Name, typeof(TRole).Name, role.Name, role.Id
+                principal.Identity!.Name, typeof(TRole).Name, role.Name, role.Id
                 );
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/IndexHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/IndexHandler.cs
@@ -35,7 +35,7 @@ internal class IndexHandler<
         return await _repository.Roles
             .AsNoTracking()
             .Select(ar => RoleInfo.Create(ar))
-            .ToListAsync();
+            .ToListAsync().ConfigureAwait(false);
     }
 
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/IndexHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/Role/IndexHandler.cs
@@ -1,10 +1,8 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 
@@ -55,19 +53,21 @@ public class RoleInfo
     /// <returns>The new <see cref="RoleInfo"/> class object.</returns>
     internal static RoleInfo Create<TRole>(TRole role) where TRole : AuthUiRole
     {
+        ArgumentNullException.ThrowIfNull(role);
+
         return new RoleInfo
         {
             Id = role.Id,
             Description = role.Description,
-            Name = role.Name
+            Name = role.Name!
         };
     }
 
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     public override string ToString()
     {

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
@@ -93,9 +93,9 @@ internal class CreateHandler<
             modelState.AddModelError(string.Empty, "Can not create User:");
             modelState.AddModelError(string.Empty, "You can not create a User with more privileges than you have.");
 
-            _logger.LogWarning(
-                "'{PrincipalEmail}' attempted to create {UserType} with elevated privileges.",
-                principal.Identity!.Name, typeof(TUser).Name
+            _logger.LogAttemptedElevatedPrivilegeUserCreation(
+                principal.Identity!.Name,
+                typeof(TUser).Name
                 );
 
             return modelBase.Page();
@@ -125,9 +125,12 @@ internal class CreateHandler<
             modelState.AddModelError(string.Empty, "Could not create User:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not create {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+            _logger.LogUserCreationFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TUser).Name,
+                user.Email,
+                user.Id
                 );
 
             return modelBase.Page();
@@ -139,9 +142,11 @@ internal class CreateHandler<
             $"User '{user.Email}' successfully created."
             );
 
-        _logger.LogInformation(
-            "'{PrincipalEmail}' created {UserType} '{UserEmail}' (ID '{UserId}').",
-            principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+        _logger.LogUserCreated(
+            principal.Identity!.Name,
+            typeof(TUser).Name,
+            user.Email,
+            user.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);
@@ -172,7 +177,7 @@ internal class CreateHandler<
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("User password validation failed: {Errors}.", string.Join(";", errors?.Select(e => e.Code) ?? []));
+                _logger.LogPasswordValidationFailed(string.Join(";", errors?.Select(e => e.Code) ?? []));
             }
             return IdentityResult.Failed([.. errors!]);
         }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
@@ -3,11 +3,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
 
@@ -71,13 +69,13 @@ internal class CreateHandler<
     /// <param name="hfRoleList">A list of Roles to be assigned to the new User.</param>
     /// <returns>The <see cref="IActionResult"/> to be used to display the next Razor page.</returns>
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
-    public async Task<IActionResult> OnPostAsync(UserModel userModel, ModelBase modelBase, string hfRoleList)
+    public async Task<IActionResult> OnPostAsync(UserModel userModel, ModelBase modelBase, string? hfRoleList)
     {
         var modelState = modelBase.ModelState;
         var principal = modelBase.User;
 
         (await userModel.InitRoleInfoAsync(_repository))
-            .SetAssignedClaims(hfRoleList?.Split(',') ?? Array.Empty<string>());
+            .SetAssignedClaims(hfRoleList?.Split(',') ?? []);
 
         if (!modelState.IsValid)
         {
@@ -95,7 +93,7 @@ internal class CreateHandler<
 
             _logger.LogWarning(
                 "'{PrincipalEmail}' attempted to create {UserType} with elevated privileges.",
-                principal.Identity.Name, typeof(TUser).Name
+                principal.Identity!.Name, typeof(TUser).Name
                 );
 
             return modelBase.Page();
@@ -126,7 +124,7 @@ internal class CreateHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not create {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return modelBase.Page();
@@ -139,7 +137,7 @@ internal class CreateHandler<
 
         _logger.LogInformation(
             "'{PrincipalEmail}' created {UserType} '{UserEmail}' (ID '{UserId}').",
-            principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+            principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);
@@ -147,7 +145,7 @@ internal class CreateHandler<
 
     private async Task<IdentityResult> ValidPasswordAsync(TUser user, string password)
     {
-        List<IdentityError> errors = null;
+        List<IdentityError> errors = null!;
         bool isValid = true;
         foreach (var passwordValidator in _userManager.PasswordValidators)
         {
@@ -159,10 +157,7 @@ internal class CreateHandler<
 
             if (identityResult.Errors.Any())
             {
-                if (errors == null)
-                {
-                    errors = [];
-                }
+                errors ??= [];
                 errors.AddRange(identityResult.Errors);
             }
 
@@ -173,9 +168,9 @@ internal class CreateHandler<
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("User password validation failed: {errors}.", string.Join(";", errors?.Select((IdentityError e) => e.Code) ?? []));
+                _logger.LogDebug("User password validation failed: {errors}.", string.Join(";", errors?.Select(e => e.Code) ?? []));
             }
-            return IdentityResult.Failed([.. errors]);
+            return IdentityResult.Failed([.. errors!]);
         }
 
         return IdentityResult.Success;

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/CreateHandler.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA1716 // Identifiers should not match keywords
+#pragma warning disable CA1724 // Type names should not match namespaces
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
@@ -57,7 +59,7 @@ internal class CreateHandler<
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public async Task<IActionResult> OnGetAsync(UserModel userModel, ModelBase modelBase)
     {
-        await userModel.InitRoleInfoAsync(_repository);
+        await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false);
         return modelBase.Page();
     }
 
@@ -74,7 +76,7 @@ internal class CreateHandler<
         var modelState = modelBase.ModelState;
         var principal = modelBase.User;
 
-        (await userModel.InitRoleInfoAsync(_repository))
+        (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false))
             .SetAssignedClaims(hfRoleList?.Split(',') ?? []);
 
         if (!modelState.IsValid)
@@ -85,7 +87,7 @@ internal class CreateHandler<
         var user = new TUser();
         userModel.UpdateUser(user);
 
-        var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.Create));
+        var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.Create)).ConfigureAwait(false);
         if (!result.Succeeded)
         {
             modelState.AddModelError(string.Empty, "Can not create User:");
@@ -99,7 +101,7 @@ internal class CreateHandler<
             return modelBase.Page();
         }
 
-        var identityResult = await ValidPasswordAsync(user, userModel.Password);
+        var identityResult = await ValidPasswordAsync(user, userModel.Password).ConfigureAwait(false);
         if (!identityResult.Succeeded)
         {
             foreach (var error in identityResult.Errors)
@@ -112,10 +114,11 @@ internal class CreateHandler<
 
         user.PasswordHash = _userManager.PasswordHasher.HashPassword(user, userModel.Password);
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
             _repository.Users.Add(user);
-            await _repository.SaveChangesAsync();
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -129,6 +132,7 @@ internal class CreateHandler<
 
             return modelBase.Page();
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         modelBase.SendNotification(
             _notificationReceiver, Severity.Normal,
@@ -168,7 +172,7 @@ internal class CreateHandler<
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("User password validation failed: {errors}.", string.Join(";", errors?.Select(e => e.Code) ?? []));
+                _logger.LogDebug("User password validation failed: {Errors}.", string.Join(";", errors?.Select(e => e.Code) ?? []));
             }
             return IdentityResult.Failed([.. errors!]);
         }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
 
@@ -118,7 +118,7 @@ internal class DeleteHandler<
 
             _logger.LogWarning(
                 "'{PrincipalEmail}' attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             (await userModel.InitRoleInfoAsync(_repository)).InitFromUser(user);
@@ -137,7 +137,7 @@ internal class DeleteHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
         }
 
@@ -157,7 +157,7 @@ internal class DeleteHandler<
 
         _logger.LogInformation(
             "'{PrincipalEmail}' deleted {UserType} '{UserEmail}' (ID '{UserId}').",
-            principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+            principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
@@ -116,9 +116,11 @@ internal class DeleteHandler<
             modelState.AddModelError(string.Empty, "Can not delete User:");
             modelState.AddModelError(string.Empty, "System accounts may not be deleted.");
 
-            _logger.LogWarning(
-                "'{PrincipalEmail}' attempted to delete system {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+            _logger.LogAttemptedSystemUserDeletion(
+                principal.Identity!.Name,
+                typeof(TUser).Name,
+                user.Email,
+                user.Id
                 );
 
             (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false)).InitFromUser(user);
@@ -136,9 +138,12 @@ internal class DeleteHandler<
             modelState.AddModelError(string.Empty, "Could not delete User:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not delete {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+            _logger.LogUserDeletionFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TUser).Name,
+                user.Email,
+                user.Id
                 );
         }
 #pragma warning restore CA1031 // Do not catch general exception types
@@ -157,9 +162,11 @@ internal class DeleteHandler<
             $"User '{user.Email}' successfully deleted."
             );
 
-        _logger.LogInformation(
-            "'{PrincipalEmail}' deleted {UserType} '{UserEmail}' (ID '{UserId}').",
-            principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+        _logger.LogUserDeleted(
+            principal.Identity!.Name,
+            typeof(TUser).Name,
+            user.Email,
+            user.Id
             );
 
         return modelBase.RedirectToPage(IndexHandler.PageName);

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DeleteHandler.cs
@@ -60,7 +60,7 @@ internal class DeleteHandler<
         var user = await _repository.Users
             .Include(au => au.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (user == null)
         {
@@ -69,7 +69,7 @@ internal class DeleteHandler<
 
         userModel.IsSystemUser = _authManager.DefinedGuids.Contains(user.Id);
 
-        (await userModel.InitRoleInfoAsync(_repository))
+        (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false))
             .InitFromUser(user);
 
         return modelBase.Page();
@@ -92,7 +92,7 @@ internal class DeleteHandler<
 
         var user = await _repository.Users
             .Include(au => au.Claims)
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (user == null)
         {
@@ -110,7 +110,7 @@ internal class DeleteHandler<
         // Don't care about ModelState on Delete.
         modelState.Clear();
 
-        var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.Delete));
+        var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.Delete)).ConfigureAwait(false);
         if (!result.Succeeded)
         {
             modelState.AddModelError(string.Empty, "Can not delete User:");
@@ -121,14 +121,15 @@ internal class DeleteHandler<
                 principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
-            (await userModel.InitRoleInfoAsync(_repository)).InitFromUser(user);
+            (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false)).InitFromUser(user);
             return modelBase.Page();
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
             _repository.Users.Remove(user);
-            await _repository.SaveChangesAsync();
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -140,10 +141,11 @@ internal class DeleteHandler<
                 principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         if (!modelState.IsValid)
         {
-            (await userModel.InitRoleInfoAsync(_repository)).InitFromUser(user);
+            (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false)).InitFromUser(user);
             return modelBase.Page();
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DetailsHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DetailsHandler.cs
@@ -2,9 +2,9 @@
 using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DetailsHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/DetailsHandler.cs
@@ -49,7 +49,7 @@ internal class DetailsHandler<
         var user = await _repository.Users
             .Include(au => au.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (user == null)
         {
@@ -58,7 +58,7 @@ internal class DetailsHandler<
 
         userModel.IsSystemUser = _authManager.DefinedGuids.Contains(user.Id);
 
-        (await userModel.InitRoleInfoAsync(_repository))
+        (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false))
             .InitFromUser(user);
 
         return modelBase.Page();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
 
@@ -86,7 +86,7 @@ internal class EditHandler<
     public async Task<IActionResult> OnPostAsync(UserModel userModel, ModelBase modelBase, string hfRoleList)
     {
         (await userModel.InitRoleInfoAsync(_repository))
-            .SetAssignedClaims(hfRoleList?.Split(',') ?? Array.Empty<string>());
+            .SetAssignedClaims(hfRoleList?.Split(',') ?? []);
 
         var modelState = modelBase.ModelState;
         var principal = modelBase.User;
@@ -120,13 +120,13 @@ internal class EditHandler<
             {
                 modelState.AddModelError(string.Empty, "Can not update User:");
 
-                if (result.Failure.FailureReason == AuthorizationFailure.Reason.SystemObject)
+                if (result.Failure!.FailureReason == AuthorizationFailure.Reason.SystemObject)
                 {
                     modelState.AddModelError(string.Empty, "You may not update the Roles assigned to a system User.");
 
                     _logger.LogWarning(
                         "'{PrincipalEmail}' attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
-                        principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                        principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                         );
                     return modelBase.Page();
                 }
@@ -136,7 +136,7 @@ internal class EditHandler<
                     modelState.AddModelError(string.Empty, "You can not give a User more privileges than you have.");
                     _logger.LogWarning(
                         "'{PrincipalEmail}' attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
-                        principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                        principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                         );
                 }
                 else
@@ -144,7 +144,7 @@ internal class EditHandler<
                     modelState.AddModelError(string.Empty, "You can not elevate your own privileges.");
                     _logger.LogWarning(
                         "'{PrincipalEmail}' attempted to elevate their own privileges.",
-                        principal.Identity.Name
+                        principal.Identity!.Name
                         );
                 }
 
@@ -163,7 +163,7 @@ internal class EditHandler<
 
             _logger.LogError(
                 ex, "'{PrincipalEmail}' could not update {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
 
             return modelBase.Page();
@@ -183,7 +183,7 @@ internal class EditHandler<
 
             _logger.LogInformation(
                 "'{PrincipalEmail}' updated {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity.Name, typeof(TUser).Name, user.Email, user.Id
+                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
                 );
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
@@ -124,9 +124,11 @@ internal class EditHandler<
                 {
                     modelState.AddModelError(string.Empty, "You may not update the Roles assigned to a system User.");
 
-                    _logger.LogWarning(
-                        "'{PrincipalEmail}' attempted to update the Roles of system {UserType} '{UserEmail}' (ID '{UserId}')",
-                        principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+                    _logger.LogAttemptedSystemUserRolesUpdate(
+                        principal.Identity!.Name,
+                        typeof(TUser).Name,
+                        user.Email,
+                        user.Id
                         );
                     return modelBase.Page();
                 }
@@ -134,16 +136,17 @@ internal class EditHandler<
                 if (principal.UserId() != user.Id)
                 {
                     modelState.AddModelError(string.Empty, "You can not give a User more privileges than you have.");
-                    _logger.LogWarning(
-                        "'{PrincipalEmail}' attempted to give {UserType} '{UserEmail}' (ID '{UserId}') elevated privileges.",
-                        principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+                    _logger.LogAttemptedElevatedPrivilegeUserUpdate(
+                        principal.Identity!.Name,
+                        typeof(TUser).Name,
+                        user.Email,
+                        user.Id
                         );
                 }
                 else
                 {
                     modelState.AddModelError(string.Empty, "You can not elevate your own privileges.");
-                    _logger.LogWarning(
-                        "'{PrincipalEmail}' attempted to elevate their own privileges.",
+                    _logger.LogAttemptedSelfPrivilegeElevation(
                         principal.Identity!.Name
                         );
                 }
@@ -162,9 +165,12 @@ internal class EditHandler<
             modelState.AddModelError(string.Empty, "Could not update User:");
             modelState.AddModelError(string.Empty, ex.GetBaseException().Message);
 
-            _logger.LogError(
-                ex, "'{PrincipalEmail}' could not update {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+            _logger.LogUserUpdateFailed(
+                ex,
+                principal.Identity!.Name,
+                typeof(TUser).Name,
+                user.Email,
+                user.Id
                 );
 
             return modelBase.Page();
@@ -183,9 +189,11 @@ internal class EditHandler<
                 $"User '{user.Email}' successfully updated."
                 );
 
-            _logger.LogInformation(
-                "'{PrincipalEmail}' updated {UserType} '{UserEmail}' (ID '{UserId}').",
-                principal.Identity!.Name, typeof(TUser).Name, user.Email, user.Id
+            _logger.LogUserUpdated(
+                principal.Identity!.Name,
+                typeof(TUser).Name,
+                user.Email,
+                user.Id
                 );
         }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/EditHandler.cs
@@ -60,7 +60,7 @@ internal class EditHandler<
         var user = await _repository.Users
             .Include(au => au.Claims)
             .AsNoTracking()
-            .FirstOrDefaultAsync(m => m.Id == id);
+            .FirstOrDefaultAsync(m => m.Id == id).ConfigureAwait(false);
 
         if (user == null)
         {
@@ -69,7 +69,7 @@ internal class EditHandler<
 
         userModel.IsSystemUser = _authManager.DefinedGuids.Contains(user.Id);
 
-        (await userModel.InitRoleInfoAsync(_repository))
+        (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false))
             .InitFromUser(user);
 
         return modelBase.Page();
@@ -85,7 +85,7 @@ internal class EditHandler<
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public async Task<IActionResult> OnPostAsync(UserModel userModel, ModelBase modelBase, string hfRoleList)
     {
-        (await userModel.InitRoleInfoAsync(_repository))
+        (await userModel.InitRoleInfoAsync(_repository).ConfigureAwait(false))
             .SetAssignedClaims(hfRoleList?.Split(',') ?? []);
 
         var modelState = modelBase.ModelState;
@@ -98,7 +98,7 @@ internal class EditHandler<
 
         var user = await _repository.Users
             .Include(au => au.Claims)
-            .FirstOrDefaultAsync(m => m.Id == userModel.Id);
+            .FirstOrDefaultAsync(m => m.Id == userModel.Id).ConfigureAwait(false);
 
         if (user == null)
         {
@@ -115,7 +115,7 @@ internal class EditHandler<
 
         if (userModel.ClaimsUpdated)
         {
-            var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.UpdateClaims));
+            var result = await _authManager.AuthorizeAsync(principal, user, new AppClaimRequirement(SysClaims.User.UpdateClaims)).ConfigureAwait(false);
             if (!result.Succeeded)
             {
                 modelState.AddModelError(string.Empty, "Can not update User:");
@@ -152,9 +152,10 @@ internal class EditHandler<
             }
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            rowsUpdated = await _repository.SaveChangesAsync();
+            rowsUpdated = await _repository.SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -168,6 +169,7 @@ internal class EditHandler<
 
             return modelBase.Page();
         }
+#pragma warning restore CA1031 // Do not catch general exception types
 
         if (rowsUpdated > 0)
         {

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/IndexHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/IndexHandler.cs
@@ -1,11 +1,9 @@
 ﻿using CRFricke.Authorization.Core.UI.Data;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.Shared.User;
 
@@ -46,17 +44,17 @@ internal class IndexHandler<
 
 public class UserInfo
 {
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [DataType(DataType.EmailAddress)]
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     [Display(Name = "Name")]
-    public string DisplayName { get; set; }
+    public string? DisplayName { get; set; }
 
     [Display(Name = "Phone Number")]
     [DataType(DataType.PhoneNumber)]
-    public string PhoneNumber { get; set; }
+    public string? PhoneNumber { get; set; }
 
     [Display(Name = "Lockout Ends On")]
     [DisplayFormat(DataFormatString = "{0:o}")]
@@ -73,8 +71,10 @@ public class UserInfo
 
     internal UserInfo InitFromUser<TUser>(TUser user) where TUser : AuthUiUser
     {
+        ArgumentNullException.ThrowIfNull(user);
+
         Id = user.Id;
-        Email = user.Email;
+        Email = user.Email!;
         DisplayName = user.DisplayName;
         PhoneNumber = user.PhoneNumber;
         LockoutEnd = user.LockoutEnd;

--- a/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/IndexHandler.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/Shared/User/IndexHandler.cs
@@ -36,7 +36,7 @@ internal class IndexHandler<
         return await _repository.Users
             .AsNoTracking()
             .Select(au => new UserInfo().InitFromUser(au))
-            .ToListAsync();
+            .ToListAsync().ConfigureAwait(false);
     }
 }
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml
@@ -44,7 +44,7 @@
                             </thead>
                             <tbody>
                                 @{
-                                    foreach (var claim in Model.RoleModel.RoleClaims)
+                                    foreach (var claim in Model.RoleModel.RoleClaims!)
                                     {
                                         var checkedVal = (claim.IsAssigned) ? "checked" : "";
                                         <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
@@ -53,6 +53,6 @@ internal class CreateModel<
 
     public override async Task<IActionResult> OnPostAsync(string hfClaimList)
     {
-        return await _createHandler.OnPostAsync(RoleModel, this, hfClaimList);
+        return await _createHandler.OnPostAsync(RoleModel, this, hfClaimList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Create.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 public abstract class CreateModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual IActionResult OnGet() => throw new NotImplementedException();
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml
@@ -62,7 +62,7 @@
                 </thead>
                 <tbody>
                     @{
-                        foreach (var user in Model.RoleModel.RoleUsers)
+                        foreach (var user in Model.RoleModel.RoleUsers!)
                         {
                             <tr>
                                 <td>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
@@ -51,12 +51,12 @@ internal class DeleteModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _deleteHandler.OnGetAsync(RoleModel, this, id);
+        return await _deleteHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.New(ConstructorInfo, IEnumerable<Expression>, MemberInfo[]): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string id)
     {
-        return await _deleteHandler.OnPostAsync(RoleModel, this, id);
+        return await _deleteHandler.OnPostAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Delete.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 public abstract class DeleteModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.New(ConstructorInfo, IEnumerable<Expression>, MemberInfo[]): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml
@@ -4,8 +4,8 @@
     ViewData["Title"] = "Role Details";
 
     var roleClaims = Model.RoleModel.Id == SysGuids.Role.Administrator
-        ? Model.RoleModel.RoleClaims.Select(rc => rc.Claim)
-        : Model.RoleModel.RoleClaims.Where(rc => rc.IsAssigned).Select(rc => rc.Claim);
+        ? Model.RoleModel.RoleClaims!.Select(rc => rc.Claim)
+        : Model.RoleModel.RoleClaims!.Where(rc => rc.IsAssigned).Select(rc => rc.Claim);
 
     var classEdit = (await AuthManager.IsAuthorizedAsync(User, SysClaims.Role.Update)) ? "" : "disabled";
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 
@@ -13,7 +13,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 [PageImplementationType(typeof(DetailsModel<,>))]
 public abstract class DetailsModel : ModelBase
 {
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual Task<IActionResult> OnGetAsync(string id)
         => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Details.cshtml.cs
@@ -41,6 +41,6 @@ internal class DetailsModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _detailsHandler.OnGetAsync(RoleModel, this, id);
+        return await _detailsHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml
@@ -59,7 +59,7 @@
                             </thead>
                             <tbody>
                                 @{
-                                    foreach (var claim in Model.RoleModel.RoleClaims)
+                                    foreach (var claim in Model.RoleModel.RoleClaims!)
                                     {
                                         var checkedVal = (claim.IsAssigned || isAdminRole) ? "checked" : "";
                                         <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
@@ -48,11 +48,11 @@ internal class EditModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _editHandler.OnGetAsync(RoleModel, this, id);
+        return await _editHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 
     public override async Task<IActionResult> OnPostAsync(string hfClaimList)
     {
-        return await _editHandler.OnPostAsync(RoleModel, this, hfClaimList);
+        return await _editHandler.OnPostAsync(RoleModel, this, hfClaimList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Edit.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 public abstract class EditModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Index.cshtml.cs
@@ -3,6 +3,7 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
@@ -11,7 +12,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    public IList<RoleInfo> RoleInfo { get; set; } = null!;
+    public IList<RoleInfo> RoleInfo { get; protected set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }
@@ -36,6 +37,6 @@ internal class IndexModel<
 
     public override async Task OnGetAsync()
     {
-        RoleInfo = await _indexHandler.OnGetAsync();
+        RoleInfo = await _indexHandler.OnGetAsync().ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/Role/Index.cshtml.cs
@@ -1,10 +1,9 @@
 using CRFricke.Authorization.Core.Attributes;
 using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 
@@ -12,7 +11,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.Role;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    public IList<RoleInfo> RoleInfo { get; set; }
+    public IList<RoleInfo> RoleInfo { get; set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml
@@ -70,7 +70,7 @@
                             </thead>
                             <tbody>
                                 @{
-                                    foreach (var role in Model.UserModel.Roles)
+                                    foreach (var role in Model.UserModel.Roles!)
                                     {
                                         var checkedVal = (role.IsAssigned) ? "checked" : "";
                                         <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
@@ -5,9 +5,9 @@ using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 
@@ -16,7 +16,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 public abstract class CreateModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync() => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Create.cshtml.cs
@@ -54,12 +54,12 @@ internal class CreateModel<
     public override async Task<IActionResult> OnGetAsync()
     {
         UserModel = new UserModel();
-        return await _createHandler.OnGetAsync(UserModel, this);
+        return await _createHandler.OnGetAsync(UserModel, this).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string hfRoleList)
     {
-        return await _createHandler.OnPostAsync(UserModel, this, hfRoleList);
+        return await _createHandler.OnPostAsync(UserModel, this, hfRoleList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml
@@ -108,7 +108,7 @@
                 </thead>
                 <tbody>
                     @{
-                        foreach (var role in Model.UserModel.Roles)
+                        foreach (var role in Model.UserModel.Roles!)
                         {
                             var checkedVal = (role.IsAssigned) ? "checked" : "";
                             <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 public abstract class DeleteModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Delete.cshtml.cs
@@ -51,12 +51,12 @@ internal class DeleteModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _deleteHandler.OnGetAsync(UserModel, this, id);
+        return await _deleteHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string id)
     {
-        return await _deleteHandler.OnPostAsync(UserModel, this, id);
+        return await _deleteHandler.OnPostAsync(UserModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml
@@ -96,7 +96,7 @@
                 </thead>
                 <tbody>
                     @{
-                        foreach (var role in Model.UserModel.Roles)
+                        foreach (var role in Model.UserModel.Roles!)
                         {
                             var checkedVal = (role.IsAssigned) ? "checked" : "";
                             <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml.cs
@@ -42,6 +42,6 @@ internal class DetailsModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _detailsHandler.OnGetAsync(UserModel, this, id);
+        return await _detailsHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Details.cshtml.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 
@@ -13,7 +13,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 [PageImplementationType(typeof(DetailsModel<,>))]
 public abstract class DetailsModel : ModelBase
 {
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml
@@ -95,7 +95,7 @@
                             </thead>
                             <tbody>
                                 @{
-                                    foreach (var role in Model.UserModel.Roles)
+                                    foreach (var role in Model.UserModel.Roles!)
                                     {
                                         var checkedVal = (role.IsAssigned) ? "checked" : "";
                                         <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 public abstract class EditModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Edit.cshtml.cs
@@ -48,12 +48,12 @@ internal class EditModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _editHandler.OnGetAsync(UserModel, this, id);
+        return await _editHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string hfRoleList)
     {
-        return await _editHandler.OnPostAsync(UserModel, this, hfRoleList);
+        return await _editHandler.OnPostAsync(UserModel, this, hfRoleList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Index.cshtml.cs
@@ -1,10 +1,9 @@
 using CRFricke.Authorization.Core.Attributes;
 using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 
@@ -12,7 +11,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    public IList<UserInfo> UserInfo { get; set; }
+    public IList<UserInfo> UserInfo { get; set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V4/User/Index.cshtml.cs
@@ -3,6 +3,7 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
@@ -11,7 +12,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V4.User;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    public IList<UserInfo> UserInfo { get; set; } = null!;
+    public IList<UserInfo> UserInfo { get; protected set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }
@@ -37,6 +38,6 @@ internal class IndexModel<
     ///<inheritdoc/>
     public override async Task OnGetAsync()
     {
-        UserInfo = await _indexHandler.OnGetAsync();
+        UserInfo = await _indexHandler.OnGetAsync().ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml
@@ -47,7 +47,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var claim in Model.RoleModel.RoleClaims)
+                            foreach (var claim in Model.RoleModel.RoleClaims!)
                             {
                                 var checkedVal = (claim.IsAssigned) ? "checked" : "";
                                 <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 
@@ -15,11 +15,11 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 public abstract class CreateModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual IActionResult OnGet() => throw new NotImplementedException();
 
-    public virtual Task<IActionResult> OnPostAsync(string hfClaimList) => throw new NotImplementedException();
+    public virtual Task<IActionResult> OnPostAsync(string? hfClaimList) => throw new NotImplementedException();
 }
 
 internal class CreateModel<
@@ -51,7 +51,7 @@ internal class CreateModel<
         return _createHandler.OnGet(RoleModel, this);
     }
 
-    public override async Task<IActionResult> OnPostAsync(string hfClaimList)
+    public override async Task<IActionResult> OnPostAsync(string? hfClaimList)
     {
         return await _createHandler.OnPostAsync(RoleModel, this, hfClaimList);
     }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Create.cshtml.cs
@@ -53,6 +53,6 @@ internal class CreateModel<
 
     public override async Task<IActionResult> OnPostAsync(string? hfClaimList)
     {
-        return await _createHandler.OnPostAsync(RoleModel, this, hfClaimList);
+        return await _createHandler.OnPostAsync(RoleModel, this, hfClaimList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml
@@ -61,7 +61,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var user in Model.RoleModel.RoleUsers)
+                            foreach (var user in Model.RoleModel.RoleUsers!)
                             {
                                 <tr>
                                     <td>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
@@ -51,12 +51,12 @@ internal class DeleteModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _deleteHandler.OnGetAsync(RoleModel, this, id);
+        return await _deleteHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.New(ConstructorInfo, IEnumerable<Expression>, MemberInfo[]): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string id)
     {
-        return await _deleteHandler.OnPostAsync(RoleModel, this, id);
+        return await _deleteHandler.OnPostAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Delete.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 public abstract class DeleteModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.New(ConstructorInfo, IEnumerable<Expression>, MemberInfo[]): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml
@@ -4,8 +4,8 @@
     ViewData["Title"] = "Role Details";
 
     var roleClaims = Model.RoleModel.Id == SysGuids.Role.Administrator
-        ? Model.RoleModel.RoleClaims.Select(rc => rc.Claim)
-        : Model.RoleModel.RoleClaims.Where(rc => rc.IsAssigned).Select(rc => rc.Claim);
+        ? Model.RoleModel.RoleClaims!.Select(rc => rc.Claim)
+        : Model.RoleModel.RoleClaims!.Where(rc => rc.IsAssigned).Select(rc => rc.Claim);
 
     var classEdit = (await AuthManager.IsAuthorizedAsync(User, SysClaims.Role.Update)) ? "" : "disabled";
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml.cs
@@ -41,6 +41,6 @@ internal class DetailsModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _detailsHandler.OnGetAsync(RoleModel, this, id);
+        return await _detailsHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Details.cshtml.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 
@@ -13,7 +13,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 [PageImplementationType(typeof(DetailsModel<,>))]
 public abstract class DetailsModel : ModelBase
 {
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual Task<IActionResult> OnGetAsync(string id)
         => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml
@@ -50,7 +50,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var claim in Model.RoleModel.RoleClaims)
+                            foreach (var claim in Model.RoleModel.RoleClaims!)
                             {
                                 var checkedVal = (claim.IsAssigned || isAdminRole) ? "checked" : "";
                                 <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
@@ -48,11 +48,11 @@ internal class EditModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         RoleModel = new RoleModel();
-        return await _editHandler.OnGetAsync(RoleModel, this, id);
+        return await _editHandler.OnGetAsync(RoleModel, this, id).ConfigureAwait(false);
     }
 
     public override async Task<IActionResult> OnPostAsync(string hfClaimList)
     {
-        return await _editHandler.OnPostAsync(RoleModel, this, hfClaimList);
+        return await _editHandler.OnPostAsync(RoleModel, this, hfClaimList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Edit.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 public abstract class EditModel : ModelBase
 {
     [BindProperty]
-    public RoleModel RoleModel { get; set; }
+    public RoleModel RoleModel { get; set; } = null!;
 
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();
 

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
@@ -1,10 +1,9 @@
 using CRFricke.Authorization.Core.Attributes;
 using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 
@@ -12,8 +11,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    private static string _basePath = null;
-    private readonly object _lockObject = new();
+    private static string _basePath = null!;
+    private readonly Lock _lockObject = new();
 
     public string BasePath
     {
@@ -37,7 +36,7 @@ public abstract class IndexModel : ModelBase
         }
     }
 
-    public IList<RoleInfo> RoleInfo { get; set; }
+    public IList<RoleInfo> RoleInfo { get; set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/Role/Index.cshtml.cs
@@ -3,6 +3,8 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.Role;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA1508 // Avoid dead conditional code
+#pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.Role;
@@ -36,7 +38,7 @@ public abstract class IndexModel : ModelBase
         }
     }
 
-    public IList<RoleInfo> RoleInfo { get; set; } = null!;
+    public IList<RoleInfo> RoleInfo { get; protected set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }
@@ -61,6 +63,6 @@ internal class IndexModel<
 
     public override async Task OnGetAsync()
     {
-        RoleInfo = await _indexHandler.OnGetAsync();
+        RoleInfo = await _indexHandler.OnGetAsync().ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml
@@ -74,7 +74,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var role in Model.UserModel.Roles)
+                            foreach (var role in Model.UserModel.Roles!)
                             {
                                 var checkedVal = (role.IsAssigned) ? "checked" : "";
                                 <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
@@ -5,9 +5,9 @@ using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 
@@ -16,13 +16,13 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 public abstract class CreateModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync() => throw new NotImplementedException();
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
-    public virtual Task<IActionResult> OnPostAsync(string hfRoleList) => throw new NotImplementedException();
+    public virtual Task<IActionResult> OnPostAsync(string? hfRoleList) => throw new NotImplementedException();
 }
 
 internal class CreateModel<
@@ -58,7 +58,7 @@ internal class CreateModel<
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
-    public override async Task<IActionResult> OnPostAsync(string hfRoleList)
+    public override async Task<IActionResult> OnPostAsync(string? hfRoleList)
     {
         return await _createHandler.OnPostAsync(UserModel, this, hfRoleList);
     }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Create.cshtml.cs
@@ -54,12 +54,12 @@ internal class CreateModel<
     public override async Task<IActionResult> OnGetAsync()
     {
         UserModel = new();
-        return await _createHandler.OnGetAsync(UserModel, this);
+        return await _createHandler.OnGetAsync(UserModel, this).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string? hfRoleList)
     {
-        return await _createHandler.OnPostAsync(UserModel, this, hfRoleList);
+        return await _createHandler.OnPostAsync(UserModel, this, hfRoleList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml
@@ -103,7 +103,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var role in Model.UserModel.Roles)
+                            foreach (var role in Model.UserModel.Roles!)
                             {
                                 var checkedVal = (role.IsAssigned) ? "checked" : "";
                                 <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
@@ -51,12 +51,12 @@ internal class DeleteModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _deleteHandler.OnGetAsync(UserModel, this, id);
+        return await _deleteHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string id)
     {
-        return await _deleteHandler.OnPostAsync(UserModel, this, id);
+        return await _deleteHandler.OnPostAsync(UserModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Delete.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 public abstract class DeleteModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml
@@ -87,7 +87,7 @@
                 </thead>
                 <tbody>
                     @{
-                        foreach (var role in Model.UserModel.Roles)
+                        foreach (var role in Model.UserModel.Roles!)
                         {
                             var checkedVal = (role.IsAssigned) ? "checked" : "";
                             <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml.cs
@@ -3,9 +3,9 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 
@@ -13,7 +13,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 [PageImplementationType(typeof(DetailsModel<,>))]
 public abstract class DetailsModel : ModelBase
 {
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Details.cshtml.cs
@@ -42,6 +42,6 @@ internal class DetailsModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _detailsHandler.OnGetAsync(UserModel, this, id);
+        return await _detailsHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml
@@ -88,7 +88,7 @@
                     </thead>
                     <tbody>
                         @{
-                            foreach (var role in Model.UserModel.Roles)
+                            foreach (var role in Model.UserModel.Roles!)
                             {
                                 var checkedVal = (role.IsAssigned) ? "checked" : "";
                                 <tr>

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
@@ -4,9 +4,9 @@ using CRFricke.Authorization.Core.UI.Models;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 
@@ -15,7 +15,7 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 public abstract class EditModel : ModelBase
 {
     [BindProperty]
-    public UserModel UserModel { get; set; }
+    public UserModel UserModel { get; set; } = null!;
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public virtual Task<IActionResult> OnGetAsync(string id) => throw new NotImplementedException();

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Edit.cshtml.cs
@@ -48,12 +48,12 @@ internal class EditModel<
     public override async Task<IActionResult> OnGetAsync(string id)
     {
         UserModel = new();
-        return await _editHandler.OnGetAsync(UserModel, this, id);
+        return await _editHandler.OnGetAsync(UserModel, this, id).ConfigureAwait(false);
     }
 
     [RequiresUnreferencedCode("System.Linq.Expressions.Expression.Bind(MethodInfo, Expression): The Property metadata or other accessor may be trimmed.")]
     public override async Task<IActionResult> OnPostAsync(string hfRoleList)
     {
-        return await _editHandler.OnPostAsync(UserModel, this, hfRoleList);
+        return await _editHandler.OnPostAsync(UserModel, this, hfRoleList).ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
@@ -1,10 +1,9 @@
 using CRFricke.Authorization.Core.Attributes;
 using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 
@@ -12,8 +11,8 @@ namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
 [PageImplementationType(typeof(IndexModel<,>))]
 public abstract class IndexModel : ModelBase
 {
-    private static string _basePath = null;
-    private readonly object _lockObject = new();
+    private static string _basePath = null!;
+    private readonly Lock _lockObject = new();
 
     public string BasePath
     {
@@ -37,7 +36,7 @@ public abstract class IndexModel : ModelBase
         }
     }
 
-    public IList<UserInfo> UserInfo { get; set; }
+    public IList<UserInfo> UserInfo { get; set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }

--- a/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
+++ b/Authorization.Core.UI/Areas/Authorization/Pages/V5/User/Index.cshtml.cs
@@ -3,6 +3,8 @@ using CRFricke.Authorization.Core.UI.Data;
 using CRFricke.Authorization.Core.UI.Pages.Shared.User;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA1508 // Avoid dead conditional code
+#pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace CRFricke.Authorization.Core.UI.Pages.V5.User;
@@ -36,7 +38,7 @@ public abstract class IndexModel : ModelBase
         }
     }
 
-    public IList<UserInfo> UserInfo { get; set; } = null!;
+    public IList<UserInfo> UserInfo { get; protected set; } = null!;
 
     public virtual Task OnGetAsync() => throw new NotImplementedException();
 }
@@ -62,6 +64,6 @@ internal class IndexModel<
     ///<inheritdoc/>
     public override async Task OnGetAsync()
     {
-        UserInfo = await _indexHandler.OnGetAsync();
+        UserInfo = await _indexHandler.OnGetAsync().ConfigureAwait(false);
     }
 }

--- a/Authorization.Core.UI/AuthCorePageApplicationModelConvention.cs
+++ b/Authorization.Core.UI/AuthCorePageApplicationModelConvention.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -17,7 +16,7 @@ internal class AuthCorePageApplicationModelConvention<TUser, TRole> : IPageAppli
     [RequiresUnreferencedCode("Call to 'System.Type.MakeGenericType(Type[])' can not be statically analyzed.")]
     public void Apply(PageApplicationModel pam)
     {
-        var attribute = pam.ModelType.GetCustomAttribute<PageImplementationTypeAttribute>();
+        var attribute = pam.ModelType!.GetCustomAttribute<PageImplementationTypeAttribute>();
         if (attribute == null)
         {
             return;
@@ -27,7 +26,7 @@ internal class AuthCorePageApplicationModelConvention<TUser, TRole> : IPageAppli
 
         if (attribute.Type.GetGenericArguments().Length == 1)
         {
-            var typeArg = pam.ModelType.Namespace.EndsWith(".User") ? typeof(TUser) : typeof(TRole);
+            var typeArg = pam.ModelType!.Namespace!.EndsWith(".User") ? typeof(TUser) : typeof(TRole);
 
             pam.ModelType = attribute.Type.MakeGenericType(typeArg).GetTypeInfo();
             return;

--- a/Authorization.Core.UI/AuthCorePageApplicationModelConvention.cs
+++ b/Authorization.Core.UI/AuthCorePageApplicationModelConvention.cs
@@ -26,7 +26,7 @@ internal class AuthCorePageApplicationModelConvention<TUser, TRole> : IPageAppli
 
         if (attribute.Type.GetGenericArguments().Length == 1)
         {
-            var typeArg = pam.ModelType!.Namespace!.EndsWith(".User") ? typeof(TUser) : typeof(TRole);
+            var typeArg = pam.ModelType!.Namespace!.EndsWith(".User", StringComparison.Ordinal) ? typeof(TUser) : typeof(TRole);
 
             pam.ModelType = attribute.Type.MakeGenericType(typeArg).GetTypeInfo();
             return;

--- a/Authorization.Core.UI/AuthCoreUIOptions.cs
+++ b/Authorization.Core.UI/AuthCoreUIOptions.cs
@@ -1,14 +1,13 @@
-﻿namespace CRFricke.Authorization.Core.UI
+﻿namespace CRFricke.Authorization.Core.UI;
+
+/// <summary>
+/// Configuration options for Authorization.Core.UI.
+/// </summary>
+public class AuthCoreUIOptions
 {
     /// <summary>
-    /// Configuration options for Authorization.Core.UI.
+    /// The friendly area name the UI should be configured under.
+    /// The default value is "Authorization".
     /// </summary>
-    public class AuthCoreUIOptions
-    {
-        /// <summary>
-        /// The friendly area name the UI should be configured under.
-        /// The default value is "Authorization".
-        /// </summary>
-        public string FriendlyAreaName { get; set; }
-    }
+    public string FriendlyAreaName { get; set; } = null!;
 }

--- a/Authorization.Core.UI/Authorization.Core.UI.csproj
+++ b/Authorization.Core.UI/Authorization.Core.UI.csproj
@@ -1,41 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>CRFricke.$(MSBuildProjectName)</AssemblyName>
 		<RootNamespace>CRFricke.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 		<IsTrimmable>false</IsTrimmable>
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Authors>Chuck Fricke</Authors>
-		<Company>Fricke Consulting</Company>
-		<Copyright>Copyright © Chuck Fricke $([System.DateTime]::Now.ToString(yyyy))</Copyright>
 		<Description>Extends ASP.NET Core Identity to include a UI for management of Users and Roles.</Description>
 		<RazorAssemblyDescription>Compiled Razor views assembly for the CRFricke.Authorization.Core.UI package.</RazorAssemblyDescription>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/CRFricke/Authorization.Core</PackageProjectUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>aspnetcore, identity, membership, authorization, UI</PackageTags>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	</PropertyGroup>
-
-	<!-- For 'push' workflow, we embed the PDB in the DLL and push the nupkg to github.com -->
-	<PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'push'">
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-
-	<!-- For 'release' workflow, we create a separate symbol package and push both to nuget.org -->
-	<PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'release'">
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	</PropertyGroup>
-
-	<!-- To get a "deterministic build" for our NuGet package: -->
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Authorization.Core.UI/ConfigureAuthCoreUIRazorOptions.cs
+++ b/Authorization.Core.UI/ConfigureAuthCoreUIRazorOptions.cs
@@ -1,53 +1,51 @@
 ﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace CRFricke.Authorization.Core.UI
+namespace CRFricke.Authorization.Core.UI;
+
+internal class ConfigureAuthCoreUIRazorOptions<TUser, TRole> : IPostConfigureOptions<RazorPagesOptions>
+    where TUser : class
+    where TRole : class
 {
-    internal class ConfigureAuthCoreUIRazorOptions<TUser, TRole> : IPostConfigureOptions<RazorPagesOptions>
-        where TUser : class
-        where TRole : class
+    public ConfigureAuthCoreUIRazorOptions(IOptions<AuthCoreUIOptions> options)
     {
-        public ConfigureAuthCoreUIRazorOptions(IOptions<AuthCoreUIOptions> options)
+        _uiOptions = options.Value;
+    }
+
+    private const string AuthCoreUIAreaName = "Authorization";
+    private readonly AuthCoreUIOptions _uiOptions;
+
+    [RequiresUnreferencedCode("System.Type.MakeGenericType(Type[]): can not be statically analyzed.")]
+    public void PostConfigure(string? name, RazorPagesOptions options)
+    {
+        name = name ?? throw new ArgumentNullException(nameof(name));
+        options = options ?? throw new ArgumentNullException(nameof(options));
+
+        var friendlyAreaName = _uiOptions.FriendlyAreaName;
+
+        if (!string.IsNullOrEmpty(friendlyAreaName))
         {
-            _uiOptions = options.Value;
+            options.Conventions
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Index", $"{friendlyAreaName}/Role")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Create", $"{friendlyAreaName}/Role/Create")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Delete", $"{friendlyAreaName}/Role/Delete")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Details", $"{friendlyAreaName}/Role/Details")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Edit", $"{friendlyAreaName}/Role/Edit")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Index", $"{friendlyAreaName}/Role/Index")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Index", $"{friendlyAreaName}/User")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Create", $"{friendlyAreaName}/User/Create")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Delete", $"{friendlyAreaName}/User/Delete")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Details", $"{friendlyAreaName}/User/Details")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Edit", $"{friendlyAreaName}/User/Edit")
+                .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Index", $"{friendlyAreaName}/User/Index");
         }
 
-        private const string AuthCoreUIAreaName = "Authorization";
-        private readonly AuthCoreUIOptions _uiOptions;
-
-        [RequiresUnreferencedCode("System.Type.MakeGenericType(Type[]): can not be statically analyzed.")]
-        public void PostConfigure(string name, RazorPagesOptions options)
-        {
-            name = name ?? throw new ArgumentNullException(nameof(name));
-            options = options ?? throw new ArgumentNullException(nameof(options));
-
-            var friendlyAreaName = _uiOptions.FriendlyAreaName;
-
-            if (!string.IsNullOrEmpty(_uiOptions.FriendlyAreaName))
-            {
-                options.Conventions
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Index", $"{friendlyAreaName}/Role")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Create", $"{friendlyAreaName}/Role/Create")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Delete", $"{friendlyAreaName}/Role/Delete")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Details", $"{friendlyAreaName}/Role/Details")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Edit", $"{friendlyAreaName}/Role/Edit")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/Role/Index", $"{friendlyAreaName}/Role/Index")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Index", $"{friendlyAreaName}/User")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Create", $"{friendlyAreaName}/User/Create")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Delete", $"{friendlyAreaName}/User/Delete")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Details", $"{friendlyAreaName}/User/Details")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Edit", $"{friendlyAreaName}/User/Edit")
-                    .AddAreaPageRoute(AuthCoreUIAreaName, "/User/Index", $"{friendlyAreaName}/User/Index");
-            }
-
-            var convention = new AuthCorePageApplicationModelConvention<TUser, TRole>();
-            options.Conventions.AddAreaFolderApplicationModelConvention(
-                AuthCoreUIAreaName,
-                "/",
-                convention.Apply);
-        }
+        var convention = new AuthCorePageApplicationModelConvention<TUser, TRole>();
+        options.Conventions.AddAreaFolderApplicationModelConvention(
+            AuthCoreUIAreaName,
+            "/",
+            convention.Apply);
     }
 }

--- a/Authorization.Core.UI/Data/AuthUiContext.cs
+++ b/Authorization.Core.UI/Data/AuthUiContext.cs
@@ -79,12 +79,12 @@ public class AuthUiContext<
     /// <inheritdoc/>
     public override async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
     {
-        await base.SeedDatabaseAsync(serviceProvider);
+        await base.SeedDatabaseAsync(serviceProvider).ConfigureAwait(false);
 
         var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
         var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<AuthUiContext>();
 
-        var role = await Roles.FindAsync(SysGuids.Role.Administrator);
+        var role = await Roles.FindAsync(SysGuids.Role.Administrator).ConfigureAwait(false);
         if (role != null)
         {
             if (role.Description == null)
@@ -99,7 +99,7 @@ public class AuthUiContext<
             }
         }
 
-        role = await Roles.FindAsync(SysUiGuids.Role.RoleManager);
+        role = await Roles.FindAsync(SysUiGuids.Role.RoleManager).ConfigureAwait(false);
         if (role == null)
         {
             role = new TRole
@@ -109,16 +109,16 @@ public class AuthUiContext<
                 Description = "RoleManagers are responsible for managing the application's Roles.",
                 NormalizedName = normalizer.NormalizeName(nameof(SysUiGuids.Role.RoleManager))
             };
-            ((AuthUiRole)role).SetClaims(SysClaims.Role.DefinedClaims);
+            role.SetClaims<AuthUiRole>(SysClaims.Role.DefinedClaims);
 
-            await Roles.AddAsync(role);
+            await Roles.AddAsync(role).ConfigureAwait(false);
             logger.LogInformation(
                 "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
                 typeof(TRole).Name, role.Name, role.Id
                 );
         }
 
-        role = await Roles.FindAsync(SysUiGuids.Role.UserManager);
+        role = await Roles.FindAsync(SysUiGuids.Role.UserManager).ConfigureAwait(false);
         if (role == null)
         {
             role = new TRole
@@ -128,22 +128,24 @@ public class AuthUiContext<
                 Description = "UserManagers are responsible for managing the application's Users.",
                 NormalizedName = normalizer.NormalizeName(nameof(SysUiGuids.Role.UserManager))
             };
-            ((AuthUiRole)role).SetClaims(SysClaims.User.DefinedClaims);
+            role.SetClaims<AuthUiRole>(SysClaims.User.DefinedClaims);
 
-            await Roles.AddAsync(role);
+            await Roles.AddAsync(role).ConfigureAwait(false);
             logger.LogInformation(
                 "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
                 typeof(TRole).Name, role.Name, role.Id
                 );
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            await SaveChangesAsync();
+            await SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "SaveChangesAsync() method failed.");
         }
+#pragma warning restore CA1031 // Do not catch general exception types
     }
 }

--- a/Authorization.Core.UI/Data/AuthUiContext.cs
+++ b/Authorization.Core.UI/Data/AuthUiContext.cs
@@ -92,9 +92,10 @@ public class AuthUiContext<
                 role.Description = "Administrators have access to all portions of the application.";
 
                 Roles.Update(role);
-                logger.LogInformation(
-                    "{RoleType} '{RoleName}' (ID: {RoleId}) has been updated.",
-                    typeof(TRole).Name, role.Name, role.Id
+                logger.LogRoleSeeded(
+                    typeof(TRole).Name,
+                    role.Name,
+                    role.Id
                     );
             }
         }
@@ -112,9 +113,10 @@ public class AuthUiContext<
             role.SetClaims<AuthUiRole>(SysClaims.Role.DefinedClaims);
 
             await Roles.AddAsync(role).ConfigureAwait(false);
-            logger.LogInformation(
-                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                typeof(TRole).Name, role.Name, role.Id
+            logger.LogRoleCreatedDuringSeed(
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
         }
 
@@ -131,9 +133,10 @@ public class AuthUiContext<
             role.SetClaims<AuthUiRole>(SysClaims.User.DefinedClaims);
 
             await Roles.AddAsync(role).ConfigureAwait(false);
-            logger.LogInformation(
-                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                typeof(TRole).Name, role.Name, role.Id
+            logger.LogRoleCreatedDuringSeed(
+                typeof(TRole).Name,
+                role.Name,
+                role.Id
                 );
         }
 
@@ -144,7 +147,7 @@ public class AuthUiContext<
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "SaveChangesAsync() method failed.");
+            logger.LogSaveChangesFailed(ex);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }

--- a/Authorization.Core.UI/Data/AuthUiContext.cs
+++ b/Authorization.Core.UI/Data/AuthUiContext.cs
@@ -3,9 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 
 namespace CRFricke.Authorization.Core.UI.Data;
 

--- a/Authorization.Core.UI/Data/AuthUiRole.cs
+++ b/Authorization.Core.UI/Data/AuthUiRole.cs
@@ -1,12 +1,11 @@
 ﻿using CRFricke.Authorization.Core.Data;
 
-namespace CRFricke.Authorization.Core.UI.Data
+namespace CRFricke.Authorization.Core.UI.Data;
+
+public class AuthUiRole : AuthRole
 {
-    public class AuthUiRole : AuthRole
-    {
-        /// <summary>
-        /// A description of the role.
-        /// </summary>
-        public virtual string Description { get; set; }
-    }
+    /// <summary>
+    /// A description of the role.
+    /// </summary>
+    public virtual string? Description { get; set; }
 }

--- a/Authorization.Core.UI/Data/AuthUiUser.cs
+++ b/Authorization.Core.UI/Data/AuthUiUser.cs
@@ -1,44 +1,43 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.AspNetCore.Identity;
 
-namespace CRFricke.Authorization.Core.UI.Data
+namespace CRFricke.Authorization.Core.UI.Data;
+
+public class AuthUiUser : AuthUser
 {
-    public class AuthUiUser : AuthUser
+    /// <summary>
+    /// Creates a new instance of the <see cref="AuthUiUser"/> class.
+    /// </summary>
+    public AuthUiUser()
+    { }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="AuthUiUser"/> class with the specified email address.
+    /// </summary>
+    /// <param name="email">The Email address of the <see cref="AuthUiUser"/>.</param>
+    public AuthUiUser(string email) : base(email)
+    { }
+
+    /// <summary>
+    /// The user's given (first) name.
+    /// </summary>
+    [ProtectedPersonalData]
+    public virtual string? GivenName { get; set; }
+
+    /// <summary>
+    /// The user's surname (last name).
+    /// </summary>
+    [ProtectedPersonalData]
+    public virtual string? Surname { get; set; }
+
+    /// <summary>
+    /// Returns the display name of the user.
+    /// </summary>
+    public string DisplayName
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="AuthUiUser"/> class.
-        /// </summary>
-        public AuthUiUser()
-        { }
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="AuthUiUser"/> class with the specified email address.
-        /// </summary>
-        /// <param name="email">The Email address of the <see cref="AuthUiUser"/>.</param>
-        public AuthUiUser(string email) : base(email)
-        { }
-
-        /// <summary>
-        /// The user's given (first) name.
-        /// </summary>
-        [ProtectedPersonalData]
-        public virtual string GivenName { get; set; }
-
-        /// <summary>
-        /// The user's surname (last name).
-        /// </summary>
-        [ProtectedPersonalData]
-        public virtual string Surname { get; set; }
-
-        /// <summary>
-        /// Returns the display name of the user.
-        /// </summary>
-        public string DisplayName
+        get
         {
-            get
-            {
-                return $"{Surname}, {GivenName}".Trim(',', ' ');
-            }
+            return $"{Surname}, {GivenName}".Trim(',', ' ');
         }
     }
 }

--- a/Authorization.Core.UI/IdentityBuilderExtensions.cs
+++ b/Authorization.Core.UI/IdentityBuilderExtensions.cs
@@ -4,266 +4,259 @@ using Microsoft.AspNetCore.Identity.UI;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
-#nullable enable
+namespace CRFricke.Authorization.Core.UI;
 
-namespace CRFricke.Authorization.Core.UI
+public static class IdentityBuilderExtensions
 {
-    public static class IdentityBuilderExtensions
+    /// <summary>
+    /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
+    /// </summary>
+    /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
+    /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
+    public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder)
     {
-        /// <summary>
-        /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
-        /// </summary>
-        /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
-        /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
-        public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder)
+        return AddAuthorizationCoreUI(builder, o => { });
+    }
+
+    /// <summary>
+    /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
+    /// </summary>
+    /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
+    /// <param name="configUIOptions">Configures the <see cref="AuthCoreUIOptions"/></param>
+    /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the <see cref="ApplicationPartManager"/> service cannot be loaded. The service should be added 
+    /// during processing of the .AddDefaultIdentity statement.
+    /// </exception>
+    public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder, Action<AuthCoreUIOptions> configUIOptions)
+    {
+        var roleType = builder.RoleType ?? typeof(IdentityUserRole<string>);
+
+        builder.Services.Configure(configUIOptions);
+
+        builder.Services.ConfigureOptions(
+            typeof(ConfigureAuthCoreUIRazorOptions<,>).MakeGenericType(builder.UserType, roleType)
+            );
+
+        var partManager = GetService<ApplicationPartManager>(builder.Services)
+            ?? throw new InvalidOperationException($"Could not load {nameof(ApplicationPartManager)} service.");
+
+        TryAddApplicationParts(partManager);
+
+        partManager.FeatureProviders.Add(
+            new ViewVersionFeatureProvider(DetermineUIFramework(builder.Services))
+            );
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Retrieves the specified service from the <see cref="IServiceCollection"/>.
+    /// <see langword="null"/>, if the requested service is not found.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="Type"/> of the requested service.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to be searched.</param>
+    /// <returns>The requested service or <see langword="null"/> if not found.</returns>
+    private static T? GetService<T>(IServiceCollection services)
+        => (T?)services.LastOrDefault(d => d.ServiceType == typeof(T))?.ImplementationInstance;
+
+    /// <summary>
+    /// If not already present, adds the <see cref="ApplicationPart"/>s for the Authorization.Core.UI package.
+    /// </summary>
+    /// <param name="partManager">The <see cref="ApplicationPartManager"/> to be updated.</param>
+    /// <returns>
+    /// <see langword="true"/>, if the <see cref="ApplicationPart"/>s were added; otherwise, <see langword="false"/>.
+    /// </returns>
+    private static bool TryAddApplicationParts(ApplicationPartManager partManager)
+    {
+        var assembly = typeof(IdentityBuilderExtensions).Assembly;
+        if (partManager.ApplicationParts.Any(ap => ap.Name == assembly.GetName().Name))
         {
-            return AddAuthorizationCoreUI(builder, o => { });
+            return false;
         }
 
-        /// <summary>
-        /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
-        /// </summary>
-        /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
-        /// <param name="configUIOptions">Configures the <see cref="AuthCoreUIOptions"/></param>
-        /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when the <see cref="ApplicationPartManager"/> service cannot be loaded. The service should be added 
-        /// during processing of the .AddDefaultIdentity statement.
-        /// </exception>
-        public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder, Action<AuthCoreUIOptions> configUIOptions)
+        var parts = new ConsolidatedAssemblyApplicationPartFactory().GetApplicationParts(assembly);
+        foreach (var part in parts)
         {
-            var roleType = builder.RoleType ?? typeof(IdentityUserRole<string>);
-
-            builder.Services.Configure(configUIOptions);
-
-            builder.Services.ConfigureOptions(
-                typeof(ConfigureAuthCoreUIRazorOptions<,>).MakeGenericType(builder.UserType, roleType)
-                );
-
-            var partManager = GetService<ApplicationPartManager>(builder.Services)
-                ?? throw new InvalidOperationException($"Could not load {nameof(ApplicationPartManager)} service.");
-
-            TryAddApplicationParts(partManager);
-
-            partManager.FeatureProviders.Add(
-                new ViewVersionFeatureProvider(DetermineUIFramework(builder.Services))
-                );
-
-            return builder;
+            partManager.ApplicationParts.Add(part);
         }
 
-        /// <summary>
-        /// Retrieves the specified service from the <see cref="IServiceCollection"/>.
-        /// <see langword="null"/>, if the requested service is not found.
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> of the requested service.</typeparam>
-        /// <param name="services">The <see cref="IServiceCollection"/> to be searched.</param>
-        /// <returns>The requested service or <see langword="null"/> if not found.</returns>
-        private static T? GetService<T>(IServiceCollection services)
-            => (T?)services.LastOrDefault(d => d.ServiceType == typeof(T))?.ImplementationInstance;
+        return true;
+    }
 
-        /// <summary>
-        /// If not already present, adds the <see cref="ApplicationPart"/>s for the Authorization.Core.UI package.
-        /// </summary>
-        /// <param name="partManager">The <see cref="ApplicationPartManager"/> to be updated.</param>
-        /// <returns>
-        /// <see langword="true"/>, if the <see cref="ApplicationPart"/>s were added; otherwise, <see langword="false"/>.
-        /// </returns>
-        private static bool TryAddApplicationParts(ApplicationPartManager partManager)
+    /// <summary>
+    /// The UI framework in use by the application.
+    /// </summary>
+    /// <remarks>
+    /// The default version must be assigned to 0.
+    /// This enum was copied from Microsoft.AspNetCore.Identity.UI
+    /// </remarks>
+    internal enum UIFramework
+    {
+        Bootstrap5 = 0,
+        Bootstrap4 = 1
+    }
+
+    /// <summary>
+    /// Determines the UI framework in use by the application.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> provided by the <see cref="IdentityBuilder"/>.</param>
+    /// <returns>The UI framework in use by the application.</returns>
+    private static UIFramework DetermineUIFramework(IServiceCollection services)
+    {
+        /// This logic is based on Microsoft.AspNetCore.Identity.UI
+        /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
+
+        if (!TryResolveUIFramework(Assembly.GetEntryAssembly(), out var framework))
         {
-            var assembly = typeof(IdentityBuilderExtensions).Assembly;
-            if (partManager.ApplicationParts.Any(ap => ap.Name == assembly.GetName().Name))
-            {
-                return false;
-            }
-
-            var parts = new ConsolidatedAssemblyApplicationPartFactory().GetApplicationParts(assembly);
-            foreach (var part in parts)
-            {
-                partManager.ApplicationParts.Add(part);
-            }
-
-            return true;
+            TryResolveUIFramework(GetApplicationAssembly(services), out framework);
         }
 
-        /// <summary>
-        /// The UI framework in use by the application.
-        /// </summary>
-        /// <remarks>
-        /// The default version must be assigned to 0.
-        /// This enum was copied from Microsoft.AspNetCore.Identity.UI
-        /// </remarks>
-        internal enum UIFramework
+        return framework;
+    }
+
+    /// <summary>
+    /// Tries to resolve the UIFramework in use by the application.
+    /// </summary>
+    /// <param name="assembly">The assembly to be checked for a <see cref="UIFrameworkAttribute"/>.</param>
+    /// <param name="uiFramework">
+    /// Output parameter that will contain the resolved UIFramework.
+    /// If this method returns <see langword="false"/>, the parameter will be set to UIFramework.Bootstrap5.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/>, if the UIFramework is successfully resolved; otherwise <see langword="false"/>
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if a <see cref="UIFrameworkAttribute"/> with an invalid UIFramework value is found.
+    /// </exception>
+    private static bool TryResolveUIFramework(Assembly? assembly, out UIFramework uiFramework)
+    {
+        /// This logic is based on Microsoft.AspNetCore.Identity.UI
+        /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
+
+        uiFramework = default; // Bootstrap5 is the default
+
+        var metadata = assembly?.GetCustomAttributes<UIFrameworkAttribute>()
+            .SingleOrDefault()?.UIFramework;
+        if (metadata == null)
         {
-            Bootstrap5 = 0,
-            Bootstrap4 = 1
+            return false;
         }
 
-        /// <summary>
-        /// Determines the UI framework in use by the application.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection"/> provided by the <see cref="IdentityBuilder"/>.</param>
-        /// <returns>The UI framework in use by the application.</returns>
-        private static UIFramework DetermineUIFramework(IServiceCollection services)
+        // If we find the metadata there must be a valid framework here.
+        if (!Enum.TryParse(metadata, ignoreCase: true, out uiFramework))
         {
-            /// This logic is based on Microsoft.AspNetCore.Identity.UI
-            /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
-
-            if (!TryResolveUIFramework(Assembly.GetEntryAssembly(), out var framework))
-            {
-                TryResolveUIFramework(GetApplicationAssembly(services), out framework);
-            }
-
-            return framework;
+            var enumValues = string.Join(", ", Enum.GetNames<UIFramework>().Select(v => $"'{v}'"));
+            throw new InvalidOperationException(
+                $"Found an invalid value for the 'IdentityUIFrameworkVersion'. Valid values are {enumValues}");
         }
 
-        /// <summary>
-        /// Tries to resolve the UIFramework in use by the application.
-        /// </summary>
-        /// <param name="assembly">The assembly to be checked for a <see cref="UIFrameworkAttribute"/>.</param>
-        /// <param name="uiFramework">
-        /// Output parameter that will contain the resolved UIFramework.
-        /// If this method returns <see langword="false"/>, the parameter will be set to UIFramework.Bootstrap5.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/>, if the UIFramework is successfully resolved; otherwise <see langword="false"/>
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if a <see cref="UIFrameworkAttribute"/> with an invalid UIFramework value is found.
-        /// </exception>
-        private static bool TryResolveUIFramework(Assembly? assembly, out UIFramework uiFramework)
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the Web Application's assembly.
+    /// </summary>
+    /// <param name="services">
+    /// The <see cref="IServiceCollection"/> provided by the <see cref="IdentityBuilder"/>.
+    /// </param>
+    /// <returns>The Web Application's assembly.</returns>
+    private static Assembly? GetApplicationAssembly(IServiceCollection services)
+    {
+        /// This code is based on Microsoft.AspNetCore.Identity.UI
+        /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
+
+        // This is the same logic that MVC follows to find the application assembly.
+        if (services.Where(d => d.ServiceType == typeof(IWebHostEnvironment))
+            .LastOrDefault()?.ImplementationInstance is not IWebHostEnvironment webHostEnvironment)
         {
-            /// This logic is based on Microsoft.AspNetCore.Identity.UI
-            /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
-
-            uiFramework = default; // Bootstrap5 is the default
-
-            var metadata = assembly?.GetCustomAttributes<UIFrameworkAttribute>()
-                .SingleOrDefault()?.UIFramework;
-            if (metadata == null)
-            {
-                return false;
-            }
-
-            // If we find the metadata there must be a valid framework here.
-            if (!Enum.TryParse(metadata, ignoreCase: true, out uiFramework))
-            {
-                var enumValues = string.Join(", ", Enum.GetNames(typeof(UIFramework)).Select(v => $"'{v}'"));
-                throw new InvalidOperationException(
-                    $"Found an invalid value for the 'IdentityUIFrameworkVersion'. Valid values are {enumValues}");
-            }
-
-            return true;
+            return null;
         }
 
-        /// <summary>
-        /// Returns the Web Application's assembly.
-        /// </summary>
-        /// <param name="services">
-        /// The <see cref="IServiceCollection"/> provided by the <see cref="IdentityBuilder"/>.
-        /// </param>
-        /// <returns>The Web Application's assembly.</returns>
-        private static Assembly? GetApplicationAssembly(IServiceCollection services)
+        var appAssembly = Assembly.Load(webHostEnvironment.ApplicationName);
+        return appAssembly;
+    }
+
+    /// <summary>
+    /// An ApplicationFeatureProvider that selects and configures the appropriate Authorization.Core.UI 
+    /// Razor Views.
+    /// </summary>
+    /// <remarks>
+    /// The Authorization.Core.UI package includes two sets of Razor pages; one built with  
+    /// Bootstrap version 4 and the other with Bootstrap version 5.
+    /// <para>
+    /// To use the version 4 pages, you must add an IdentityUIFrameworkVersion parameter that specifies 
+    /// "Bootstrap4" to the application's project file (inside a PropertyGroup).
+    /// If the parameter is not added to the application's project file, the version 5 pages are used.
+    /// </para>
+    /// </remarks>
+    internal class ViewVersionFeatureProvider : IApplicationFeatureProvider<ViewsFeature>
+    {
+        /// This code was lifted from Microsoft.AspNetCore.Identity.UI
+        /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
+
+        private readonly UIFramework _framework;
+
+        public ViewVersionFeatureProvider(UIFramework framework) => _framework = framework;
+
+        public void PopulateFeature(IEnumerable<ApplicationPart> parts, ViewsFeature feature)
         {
-            /// This code is based on Microsoft.AspNetCore.Identity.UI
-            /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
-
-            // This is the same logic that MVC follows to find the application assembly.
-            var webHostEnvironment = services.Where(d => d.ServiceType == typeof(IWebHostEnvironment))
-                .LastOrDefault()?.ImplementationInstance as IWebHostEnvironment;
-            if (webHostEnvironment == null)
+            var viewsToRemove = new List<CompiledViewDescriptor>();
+            foreach (var descriptor in feature.ViewDescriptors)
             {
-                return null;
-            }
-
-            var appAssembly = Assembly.Load(webHostEnvironment.ApplicationName);
-            return appAssembly;
-        }
-
-        /// <summary>
-        /// An ApplicationFeatureProvider that selects and configures the appropriate Authorization.Core.UI 
-        /// Razor Views.
-        /// </summary>
-        /// <remarks>
-        /// The Authorization.Core.UI package includes two sets of Razor pages; one built with  
-        /// Bootstrap version 4 and the other with Bootstrap version 5.
-        /// <para>
-        /// To use the version 4 pages, you must add an IdentityUIFrameworkVersion parameter that specifies 
-        /// "Bootstrap4" to the application's project file (inside a PropertyGroup).
-        /// If the parameter is not added to the application's project file, the version 5 pages are used.
-        /// </para>
-        /// </remarks>
-        internal class ViewVersionFeatureProvider : IApplicationFeatureProvider<ViewsFeature>
-        {
-            /// This code was lifted from Microsoft.AspNetCore.Identity.UI
-            /// https://github.com/dotnet/aspnetcore/blob/main/src/Identity/UI/src/IdentityBuilderUIExtensions.cs
-
-            private readonly UIFramework _framework;
-
-            public ViewVersionFeatureProvider(UIFramework framework) => _framework = framework;
-
-            public void PopulateFeature(IEnumerable<ApplicationPart> parts, ViewsFeature feature)
-            {
-                var viewsToRemove = new List<CompiledViewDescriptor>();
-                foreach (var descriptor in feature.ViewDescriptors)
+                if (IsAuthorizationUIView(descriptor))
                 {
-                    if (IsAuthorizationUIView(descriptor))
+                    switch (_framework)
                     {
-                        switch (_framework)
-                        {
-                            case UIFramework.Bootstrap4:
-                                if (descriptor.Type?.FullName?.Contains("V5") ?? false)
-                                {
-                                    // Remove V5 views
-                                    viewsToRemove.Add(descriptor);
-                                }
-                                else
-                                {
-                                    // Fix up paths to eliminate version subdir
-                                    descriptor.RelativePath = descriptor.RelativePath.Replace("V4/", "");
-                                }
-                                break;
-                            case UIFramework.Bootstrap5:
-                                if (descriptor.Type?.FullName?.Contains("V4") ?? false)
-                                {
-                                    // Remove V4 views
-                                    viewsToRemove.Add(descriptor);
-                                }
-                                else
-                                {
-                                    // Fix up paths to eliminate version subdir
-                                    descriptor.RelativePath = descriptor.RelativePath.Replace("V5/", "");
-                                }
-                                break;
-                            default:
-                                throw new InvalidOperationException($"Unknown framework: {_framework}");
-                        }
+                        case UIFramework.Bootstrap4:
+                            if (descriptor.Type?.FullName?.Contains("V5") ?? false)
+                            {
+                                // Remove V5 views
+                                viewsToRemove.Add(descriptor);
+                            }
+                            else
+                            {
+                                // Fix up paths to eliminate version subdir
+                                descriptor.RelativePath = descriptor.RelativePath.Replace("V4/", "");
+                            }
+                            break;
+                        case UIFramework.Bootstrap5:
+                            if (descriptor.Type?.FullName?.Contains("V4") ?? false)
+                            {
+                                // Remove V4 views
+                                viewsToRemove.Add(descriptor);
+                            }
+                            else
+                            {
+                                // Fix up paths to eliminate version subdir
+                                descriptor.RelativePath = descriptor.RelativePath.Replace("V5/", "");
+                            }
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unknown framework: {_framework}");
                     }
                 }
-
-                foreach (var descriptorToRemove in viewsToRemove)
-                {
-                    feature.ViewDescriptors.Remove(descriptorToRemove);
-                }
             }
 
-            /// <summary>
-            /// Returns an indication of whether the specified <see cref="CompiledViewDescriptor"/> describes 
-            /// a Razor View contained in the Authorization.Core.UI assembly.
-            /// </summary>
-            /// <param name="descriptor">the <see cref="CompiledViewDescriptor"/> to be checked.</param>
-            /// <returns>
-            /// <see langword="true"/>, if the <paramref name="descriptor"/> describes a Razor View contained in 
-            /// the Authorization.Core.UI assembly; otherwise, <see langword="false"/>.
-            /// </returns>
-            private static bool IsAuthorizationUIView(CompiledViewDescriptor descriptor)
-                => descriptor.RelativePath.StartsWith("/Areas/Authorization", StringComparison.OrdinalIgnoreCase) 
-                    && descriptor?.Type?.Assembly == typeof(IdentityBuilderExtensions).Assembly;
+            foreach (var descriptorToRemove in viewsToRemove)
+            {
+                feature.ViewDescriptors.Remove(descriptorToRemove);
+            }
         }
+
+        /// <summary>
+        /// Returns an indication of whether the specified <see cref="CompiledViewDescriptor"/> describes 
+        /// a Razor View contained in the Authorization.Core.UI assembly.
+        /// </summary>
+        /// <param name="descriptor">the <see cref="CompiledViewDescriptor"/> to be checked.</param>
+        /// <returns>
+        /// <see langword="true"/>, if the <paramref name="descriptor"/> describes a Razor View contained in 
+        /// the Authorization.Core.UI assembly; otherwise, <see langword="false"/>.
+        /// </returns>
+        private static bool IsAuthorizationUIView(CompiledViewDescriptor descriptor)
+            => descriptor.RelativePath.StartsWith("/Areas/Authorization", StringComparison.OrdinalIgnoreCase) 
+                && descriptor?.Type?.Assembly == typeof(IdentityBuilderExtensions).Assembly;
     }
 }

--- a/Authorization.Core.UI/IdentityBuilderExtensions.cs
+++ b/Authorization.Core.UI/IdentityBuilderExtensions.cs
@@ -10,46 +10,47 @@ namespace CRFricke.Authorization.Core.UI;
 
 public static class IdentityBuilderExtensions
 {
-    /// <summary>
-    /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
-    /// </summary>
-    /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
-    /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
-    public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder)
+    extension(IdentityBuilder builder)
     {
-        return AddAuthorizationCoreUI(builder, o => { });
-    }
+        /// <summary>
+        /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
+        /// </summary>
+        /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
+        public IdentityBuilder AddAuthorizationCoreUI()
+        {
+            return AddAuthorizationCoreUI(builder, o => { });
+        }
 
-    /// <summary>
-    /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
-    /// </summary>
-    /// <param name="builder">The <see cref="IdentityBuilder"/>.</param>
-    /// <param name="configUIOptions">Configures the <see cref="AuthCoreUIOptions"/></param>
-    /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the <see cref="ApplicationPartManager"/> service cannot be loaded. The service should be added 
-    /// during processing of the .AddDefaultIdentity statement.
-    /// </exception>
-    public static IdentityBuilder AddAuthorizationCoreUI(this IdentityBuilder builder, Action<AuthCoreUIOptions> configUIOptions)
-    {
-        var roleType = builder.RoleType ?? typeof(IdentityUserRole<string>);
+        /// <summary>
+        /// Adds a default, self contained, UI for managing the User and Role entities exposed by the Authorization.Core package.
+        /// </summary>
+        /// <param name="configUIOptions">Configures the <see cref="AuthCoreUIOptions"/></param>
+        /// <returns>The same <see cref="IdentityBuilder"/> so multiple calls can be chained.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the <see cref="ApplicationPartManager"/> service cannot be loaded. The service should be added 
+        /// during processing of the .AddDefaultIdentity statement.
+        /// </exception>
+        public IdentityBuilder AddAuthorizationCoreUI(Action<AuthCoreUIOptions> configUIOptions)
+        {
+            var roleType = builder.RoleType ?? typeof(IdentityUserRole<string>);
 
-        builder.Services.Configure(configUIOptions);
+            builder.Services.Configure(configUIOptions);
 
-        builder.Services.ConfigureOptions(
-            typeof(ConfigureAuthCoreUIRazorOptions<,>).MakeGenericType(builder.UserType, roleType)
-            );
+            builder.Services.ConfigureOptions(
+                typeof(ConfigureAuthCoreUIRazorOptions<,>).MakeGenericType(builder.UserType, roleType)
+                );
 
-        var partManager = GetService<ApplicationPartManager>(builder.Services)
-            ?? throw new InvalidOperationException($"Could not load {nameof(ApplicationPartManager)} service.");
+            var partManager = GetService<ApplicationPartManager>(builder.Services)
+                ?? throw new InvalidOperationException($"Could not load {nameof(ApplicationPartManager)} service.");
 
-        TryAddApplicationParts(partManager);
+            TryAddApplicationParts(partManager);
 
-        partManager.FeatureProviders.Add(
-            new ViewVersionFeatureProvider(DetermineUIFramework(builder.Services))
-            );
+            partManager.FeatureProviders.Add(
+                new ViewVersionFeatureProvider(DetermineUIFramework(builder.Services))
+                );
 
-        return builder;
+            return builder;
+        }
     }
 
     /// <summary>
@@ -211,7 +212,7 @@ public static class IdentityBuilderExtensions
                     switch (_framework)
                     {
                         case UIFramework.Bootstrap4:
-                            if (descriptor.Type?.FullName?.Contains("V5") ?? false)
+                            if (descriptor.Type?.FullName?.Contains("V5", StringComparison.Ordinal) ?? false)
                             {
                                 // Remove V5 views
                                 viewsToRemove.Add(descriptor);
@@ -219,11 +220,11 @@ public static class IdentityBuilderExtensions
                             else
                             {
                                 // Fix up paths to eliminate version subdir
-                                descriptor.RelativePath = descriptor.RelativePath.Replace("V4/", "");
+                                descriptor.RelativePath = descriptor.RelativePath.Replace("V4/", "", StringComparison.Ordinal);
                             }
                             break;
                         case UIFramework.Bootstrap5:
-                            if (descriptor.Type?.FullName?.Contains("V4") ?? false)
+                            if (descriptor.Type?.FullName?.Contains("V4", StringComparison.Ordinal) ?? false)
                             {
                                 // Remove V4 views
                                 viewsToRemove.Add(descriptor);
@@ -231,7 +232,7 @@ public static class IdentityBuilderExtensions
                             else
                             {
                                 // Fix up paths to eliminate version subdir
-                                descriptor.RelativePath = descriptor.RelativePath.Replace("V5/", "");
+                                descriptor.RelativePath = descriptor.RelativePath.Replace("V5/", "", StringComparison.Ordinal);
                             }
                             break;
                         default:

--- a/Authorization.Core.UI/LoggerExtensions.cs
+++ b/Authorization.Core.UI/LoggerExtensions.cs
@@ -1,0 +1,272 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace CRFricke.Authorization.Core.UI;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(
+        EventId = 1001,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to create {roleType} with elevated privileges.")]
+    public static partial void LogAttemptedElevatedPrivilegeRoleCreation(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType);
+
+    [LoggerMessage(
+        EventId = 1002,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not create {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleCreationFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1003,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' created {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleCreated(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1004,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to delete system {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogAttemptedSystemRoleDeletion(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1005,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not delete {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleDeletionFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1006,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' deleted {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleDeleted(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1007,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to update the claims of system {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogAttemptedSystemRoleClaimsUpdate(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1008,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to give {roleType} '{roleName}' (ID: {roleId}) elevated privileges.")]
+    public static partial void LogAttemptedElevatedPrivilegeRoleUpdate(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1009,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not update {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleUpdateFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1010,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' updated {roleType} '{roleName}' (ID: {roleId}).")]
+    public static partial void LogRoleUpdated(
+        this ILogger logger,
+        string? principalEmail,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1011,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to create {userType} with elevated privileges.")]
+    public static partial void LogAttemptedElevatedPrivilegeUserCreation(
+        this ILogger logger,
+        string? principalEmail,
+        string userType);
+
+    [LoggerMessage(
+        EventId = 1012,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not create {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserCreationFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1013,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' created {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserCreated(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1014,
+        Level = LogLevel.Debug,
+        Message = "User password validation failed: {errors}.")]
+    public static partial void LogPasswordValidationFailed(
+        this ILogger logger,
+        string errors);
+
+    [LoggerMessage(
+        EventId = 1015,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to delete system {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogAttemptedSystemUserDeletion(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1016,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not delete {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserDeletionFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1017,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' deleted {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserDeleted(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1018,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to update the Roles of system {userType} '{userEmail}' (ID '{userId}')")]
+    public static partial void LogAttemptedSystemUserRolesUpdate(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1019,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to give {userType} '{userEmail}' (ID '{userId}') elevated privileges.")]
+    public static partial void LogAttemptedElevatedPrivilegeUserUpdate(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1020,
+        Level = LogLevel.Warning,
+        Message = "'{principalEmail}' attempted to elevate their own privileges.")]
+    public static partial void LogAttemptedSelfPrivilegeElevation(
+        this ILogger logger,
+        string? principalEmail);
+
+    [LoggerMessage(
+        EventId = 1021,
+        Level = LogLevel.Error,
+        Message = "'{principalEmail}' could not update {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserUpdateFailed(
+        this ILogger logger,
+        Exception exception,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1022,
+        Level = LogLevel.Information,
+        Message = "'{principalEmail}' updated {userType} '{userEmail}' (ID '{userId}').")]
+    public static partial void LogUserUpdated(
+        this ILogger logger,
+        string? principalEmail,
+        string userType,
+        string? userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 1023,
+        Level = LogLevel.Information,
+        Message = "{roleType} '{roleName}' (ID: {roleId}) has been updated.")]
+    public static partial void LogRoleSeeded(
+        this ILogger logger,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1024,
+        Level = LogLevel.Information,
+        Message = "{roleType} '{roleName}' (ID: {roleId}) has been created.")]
+    public static partial void LogRoleCreatedDuringSeed(
+        this ILogger logger,
+        string roleType,
+        string? roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 1025,
+        Level = LogLevel.Error,
+        Message = "SaveChangesAsync() method failed.")]
+    public static partial void LogSaveChangesFailed(
+        this ILogger logger,
+        Exception exception);
+}

--- a/Authorization.Core.UI/PageImplementationTypeAttribute.cs
+++ b/Authorization.Core.UI/PageImplementationTypeAttribute.cs
@@ -1,5 +1,7 @@
 ﻿namespace CRFricke.Authorization.Core.UI;
 
+#pragma warning disable CA1019 // Define accessors for attribute arguments
+
 /// <summary>
 /// Specifies the generic type template to be used to instantiate the model for the associated razor page.
 /// </summary>

--- a/Authorization.Core.UI/PageImplementationTypeAttribute.cs
+++ b/Authorization.Core.UI/PageImplementationTypeAttribute.cs
@@ -1,20 +1,17 @@
-﻿using System;
+﻿namespace CRFricke.Authorization.Core.UI;
 
-namespace CRFricke.Authorization.Core.UI
+/// <summary>
+/// Specifies the generic type template to be used to instantiate the model for the associated razor page.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+internal sealed class PageImplementationTypeAttribute : Attribute
 {
-    /// <summary>
-    /// Specifies the generic type template to be used to instantiate the model for the associated razor page.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-    internal sealed class PageImplementationTypeAttribute : Attribute
+    public PageImplementationTypeAttribute(Type implementationType)
     {
-        public PageImplementationTypeAttribute(Type implementationType)
-        {
-            Type = implementationType;
-        }
-        /// <summary>
-        /// The generic type template to be used to instantiate the model for the associated razor page.
-        /// </summary>
-        public Type Type { get; }
+        Type = implementationType;
     }
+    /// <summary>
+    /// The generic type template to be used to instantiate the model for the associated razor page.
+    /// </summary>
+    public Type Type { get; }
 }

--- a/Authorization.Core.UI/SysUiGuids.cs
+++ b/Authorization.Core.UI/SysUiGuids.cs
@@ -1,37 +1,36 @@
-﻿using System.Collections.Generic;
+﻿#pragma warning disable CA1034 // Nested types should not be visible
 
-namespace CRFricke.Authorization.Core.UI
+namespace CRFricke.Authorization.Core.UI;
+
+/// <summary>
+/// Defines the Guids used by the Authorization system UI.
+/// </summary>
+public class SysUiGuids
 {
     /// <summary>
-    /// Defines the Guids used by the Authorization system UI.
+    /// The Guids of the system Roles.
     /// </summary>
-    public class SysUiGuids
+    public class Role : IDefinesGuids
     {
         /// <summary>
-        /// The Guids of the system Roles.
+        /// The Guid assigned to the RoleManager Role.
         /// </summary>
-        public class Role : IDefinesGuids
-        {
-            /// <summary>
-            /// The Guid assigned to the RoleManager Role.
-            /// </summary>
-            public const string RoleManager = "5e79c59c-b0c1-4857-8f3a-d99dbd1e099f";
+        public const string RoleManager = "5e79c59c-b0c1-4857-8f3a-d99dbd1e099f";
 
-            /// <summary>
-            /// The Guid assigned to the UserManager Role.
-            /// </summary>
-            public const string UserManager = "d29ad18a-eaae-407c-8398-92a99182148a";
+        /// <summary>
+        /// The Guid assigned to the UserManager Role.
+        /// </summary>
+        public const string UserManager = "d29ad18a-eaae-407c-8398-92a99182148a";
 
-            /// <summary>
-            /// Returns a list of all GUIDs defined for Role entities.
-            /// </summary>
-            public static readonly List<string> DefinedGuids = new()
-            {
-                RoleManager, UserManager
-            };
+        /// <summary>
+        /// Returns a list of all GUIDs defined for Role entities.
+        /// </summary>
+        public static readonly List<string> DefinedGuids =
+        [
+            RoleManager, UserManager
+        ];
 
-            ///<inheritdoc/>
-            List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
-        }
+        ///<inheritdoc/>
+        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 }

--- a/Authorization.Core.UI/SysUiGuids.cs
+++ b/Authorization.Core.UI/SysUiGuids.cs
@@ -1,11 +1,13 @@
-﻿#pragma warning disable CA1034 // Nested types should not be visible
+﻿namespace CRFricke.Authorization.Core.UI;
 
-namespace CRFricke.Authorization.Core.UI;
+#pragma warning disable CA1033 // Interface methods should be callable by child types
+#pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable CA1724 // Type names should not match namespaces
 
 /// <summary>
 /// Defines the Guids used by the Authorization system UI.
 /// </summary>
-public class SysUiGuids
+public static class SysUiGuids
 {
     /// <summary>
     /// The Guids of the system Roles.
@@ -25,12 +27,12 @@ public class SysUiGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for Role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             RoleManager, UserManager
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 }

--- a/Authorization.Core.UI/TempDataDictionaryExtensions.cs
+++ b/Authorization.Core.UI/TempDataDictionaryExtensions.cs
@@ -1,54 +1,45 @@
 ﻿using CRFricke.Authorization.Core.UI.Pages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace CRFricke.Authorization.Core.UI
+namespace CRFricke.Authorization.Core.UI;
+
+public static class TempDataDictionaryExtensions
 {
-    public static class TempDataDictionaryExtensions
+    /// <summary>
+    /// Saves the specified <see cref="Notification"/> collection in the TempData Dictionary.
+    /// </summary>
+    /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> to be updated.</param>
+    /// <param name="key">The key to be used when saving the Notification collection.</param>
+    /// <param name="notifications">The Notification collection to be saved.</param>
+    public static void SetNotifications(this ITempDataDictionary tempDataDictionary, string key, List<Notification> notifications)
     {
-        /// <summary>
-        /// Saves the specified <see cref="Notification"/> collection in the TempData Dictionary.
-        /// </summary>
-        /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> to be updated.</param>
-        /// <param name="key">The key to be used when saving the Notification collection.</param>
-        /// <param name="notifications">The Notification collection to be saved.</param>
-        public static void SetNotifications(this ITempDataDictionary tempDataDictionary, string key, List<Notification> notifications)
-        {
-            if (tempDataDictionary == null)
-            {
-                throw new ArgumentNullException(nameof(tempDataDictionary));
-            }
+        ArgumentNullException.ThrowIfNull(tempDataDictionary);
 
-            tempDataDictionary[key] = JsonSerializer.Serialize(notifications, NotificationSerializerContext.Default.ListNotification);
-        }
-
-        /// <summary>
-        /// Retrieves the <see cref="Notification"/> collection with the specified key from the TempData Dictionary.
-        /// </summary>
-        /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> that contains the collection to be retrieved.</param>
-        /// <param name="key">The key to use when retrieving the collection from the TempData Dictionary.</param>
-        /// <returns>The requested <see cref="Notification"/> collection; <em>null</em>, if not found.</returns>
-        public static List<Notification> GetNotifications(this ITempDataDictionary tempDataDictionary, string key)
-        {
-            if (tempDataDictionary == null)
-            {
-                throw new ArgumentNullException(nameof(tempDataDictionary));
-            }
-
-            var jsonString = (string)tempDataDictionary[key];
-            if (string.IsNullOrEmpty(jsonString))
-            {
-                return default;
-            }
-
-            return JsonSerializer.Deserialize(jsonString, NotificationSerializerContext.Default.ListNotification);
-        }
+        tempDataDictionary[key] = JsonSerializer.Serialize(notifications, NotificationSerializerContext.Default.ListNotification);
     }
 
-    [JsonSerializable(typeof(List<Notification>))]
-    internal partial class NotificationSerializerContext : JsonSerializerContext 
-    { }
+    /// <summary>
+    /// Retrieves the <see cref="Notification"/> collection with the specified key from the TempData Dictionary.
+    /// </summary>
+    /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> that contains the collection to be retrieved.</param>
+    /// <param name="key">The key to use when retrieving the collection from the TempData Dictionary.</param>
+    /// <returns>The requested <see cref="Notification"/> collection; <em>null</em>, if not found.</returns>
+    public static List<Notification>? GetNotifications(this ITempDataDictionary tempDataDictionary, string key)
+    {
+        ArgumentNullException.ThrowIfNull(tempDataDictionary);
+
+        var jsonString = tempDataDictionary[key] as string;
+        if (string.IsNullOrEmpty(jsonString))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize(jsonString, NotificationSerializerContext.Default.ListNotification);
+    }
 }
+
+[JsonSerializable(typeof(List<Notification>))]
+internal partial class NotificationSerializerContext : JsonSerializerContext 
+{ }

--- a/Authorization.Core.UI/TempDataDictionaryExtensions.cs
+++ b/Authorization.Core.UI/TempDataDictionaryExtensions.cs
@@ -7,36 +7,34 @@ namespace CRFricke.Authorization.Core.UI;
 
 public static class TempDataDictionaryExtensions
 {
-    /// <summary>
-    /// Saves the specified <see cref="Notification"/> collection in the TempData Dictionary.
-    /// </summary>
-    /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> to be updated.</param>
-    /// <param name="key">The key to be used when saving the Notification collection.</param>
-    /// <param name="notifications">The Notification collection to be saved.</param>
-    public static void SetNotifications(this ITempDataDictionary tempDataDictionary, string key, List<Notification> notifications)
+    extension(ITempDataDictionary tempDataDictionary)
     {
-        ArgumentNullException.ThrowIfNull(tempDataDictionary);
-
-        tempDataDictionary[key] = JsonSerializer.Serialize(notifications, NotificationSerializerContext.Default.ListNotification);
-    }
-
-    /// <summary>
-    /// Retrieves the <see cref="Notification"/> collection with the specified key from the TempData Dictionary.
-    /// </summary>
-    /// <param name="tempDataDictionary">The <see cref="ITempDataDictionary"/> that contains the collection to be retrieved.</param>
-    /// <param name="key">The key to use when retrieving the collection from the TempData Dictionary.</param>
-    /// <returns>The requested <see cref="Notification"/> collection; <em>null</em>, if not found.</returns>
-    public static List<Notification>? GetNotifications(this ITempDataDictionary tempDataDictionary, string key)
-    {
-        ArgumentNullException.ThrowIfNull(tempDataDictionary);
-
-        var jsonString = tempDataDictionary[key] as string;
-        if (string.IsNullOrEmpty(jsonString))
+        /// <summary>
+        /// Saves the specified <see cref="Notification"/> collection in the TempData Dictionary.
+        /// </summary>
+        /// <param name="key">The key to be used when saving the Notification collection.</param>
+        /// <param name="notifications">The Notification collection to be saved.</param>
+        public void SetNotifications(string key, IEnumerable<Notification> notifications)
         {
-            return default;
+            var notificationList = notifications as List<Notification> ?? [.. notifications];
+            tempDataDictionary[key] = JsonSerializer.Serialize(notificationList, NotificationSerializerContext.Default.ListNotification);
         }
 
-        return JsonSerializer.Deserialize(jsonString, NotificationSerializerContext.Default.ListNotification);
+        /// <summary>
+        /// Retrieves the <see cref="Notification"/> collection with the specified key from the TempData Dictionary.
+        /// </summary>
+        /// <param name="key">The key to use when retrieving the collection from the TempData Dictionary.</param>
+        /// <returns>The requested <see cref="Notification"/> collection; <em>null</em>, if not found.</returns>
+        public  IList<Notification>? GetNotifications(string key)
+        {
+            var jsonString = tempDataDictionary[key] as string;
+            if (string.IsNullOrEmpty(jsonString))
+            {
+                return default;
+            }
+
+            return JsonSerializer.Deserialize(jsonString, NotificationSerializerContext.Default.ListNotification);
+        }
     }
 }
 

--- a/Authorization.Core.slnx
+++ b/Authorization.Core.slnx
@@ -1,5 +1,7 @@
 <Solution>
   <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
     <File Path="global.json" />
     <File Path="nuget.config" />

--- a/Authorization.Core/AppClaimRequirement.cs
+++ b/Authorization.Core/AppClaimRequirement.cs
@@ -1,38 +1,35 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Represents an authorization requirement for one or more application claim values.
+/// </summary>
+public class AppClaimRequirement : IAuthorizationRequirement
 {
     /// <summary>
-    /// Represents an authorization requirement for one or more application claim values.
+    /// Creates a new instance of the AppClaimRequirement class using the specified claim values.
     /// </summary>
-    public class AppClaimRequirement : IAuthorizationRequirement
+    /// <param name="claimValues">The required claim value(s).</param>
+    public AppClaimRequirement(params string[] claimValues)
     {
-        /// <summary>
-        /// Creates a new instance of the AppClaimRequirement class using the specified claim values.
-        /// </summary>
-        /// <param name="claimValues">The required claim value(s).</param>
-        public AppClaimRequirement(params string[] claimValues)
-        {
-            ClaimValues = claimValues.ToHashSet();
-        }
+        ClaimValues = [.. claimValues];
+    }
 
-        /// <summary>
-        /// The claim type of the associated application claims.
-        /// </summary>
-        public const string ClaimType = ClaimTypes.AuthorizationDecision;
+    /// <summary>
+    /// The claim type of the associated application claims.
+    /// </summary>
+    public const string ClaimType = ClaimTypes.AuthorizationDecision;
 
-        /// <summary>
-        /// The claim value(s) associated with this AuthorizationRequirement.
-        /// </summary>
-        public HashSet<string> ClaimValues { get; }
+    /// <summary>
+    /// The claim value(s) associated with this AuthorizationRequirement.
+    /// </summary>
+    public HashSet<string> ClaimValues { get; }
 
-        ///<inheritdoc/>
-        public override string ToString()
-        {
-            return $"{string.Join(", ", ClaimValues)}";
-        }
+    ///<inheritdoc/>
+    public override string ToString()
+    {
+        return $"{string.Join(", ", ClaimValues)}";
     }
 }

--- a/Authorization.Core/AppClaimRequirementHandler.cs
+++ b/Authorization.Core/AppClaimRequirementHandler.cs
@@ -1,41 +1,31 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Authorization handler for AppClaimRequirements
+/// </summary>
+public class AppClaimRequirementHandler : AuthorizationHandler<AppClaimRequirement, object>
 {
+    private readonly IAuthorizationManager _authorizationManager;
+
     /// <summary>
-    /// Authorization handler for AppClaimRequirements
+    /// Creates a new instance of the AppClaimRequirementHandler class using the specified AuthorizationManager.
     /// </summary>
-    public class AppClaimRequirementHandler : AuthorizationHandler<AppClaimRequirement, object>
+    /// <param name="authorizationManager">The <see cref="IAuthorizationManager"/> to be used for evaluating AppClaimRequirements.</param>
+    public AppClaimRequirementHandler(IAuthorizationManager authorizationManager)
     {
-        private readonly IAuthorizationManager _authorizationManager;
+        _authorizationManager = authorizationManager;
+    }
 
-        /// <summary>
-        /// Creates a new instance of the AppClaimRequirementHandler class using the specified AuthorizationManager.
-        /// </summary>
-        /// <param name="authorizationManager">The <see cref="IAuthorizationManager"/> to be used for evaluating AppClaimRequirements.</param>
-        public AppClaimRequirementHandler(IAuthorizationManager authorizationManager)
+    /// <inheritdoc/>
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, AppClaimRequirement requirement, object resource)
+    {
+        AuthorizationResult result;
+
+        if (resource is not IRequiresAuthorization)
         {
-            _authorizationManager = authorizationManager;
-        }
-
-        /// <inheritdoc/>
-        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, AppClaimRequirement requirement, object resource)
-        {
-            AuthorizationResult result;
-
-            if (resource is not IRequiresAuthorization)
-            {
-                result = await _authorizationManager.AuthorizeAsync(context.User, requirement);
-                if (result.Succeeded)
-                {
-                    context.Succeed(requirement);
-                }
-
-                return;
-            }
-
-            result = await _authorizationManager.AuthorizeAsync(context.User, resource, requirement);
+            result = await _authorizationManager.AuthorizeAsync(context.User, requirement);
             if (result.Succeeded)
             {
                 context.Succeed(requirement);
@@ -43,5 +33,13 @@ namespace CRFricke.Authorization.Core
 
             return;
         }
+
+        result = await _authorizationManager.AuthorizeAsync(context.User, resource, requirement);
+        if (result.Succeeded)
+        {
+            context.Succeed(requirement);
+        }
+
+        return;
     }
 }

--- a/Authorization.Core/AppClaimRequirementHandler.cs
+++ b/Authorization.Core/AppClaimRequirementHandler.cs
@@ -21,11 +21,13 @@ public class AppClaimRequirementHandler : AuthorizationHandler<AppClaimRequireme
     /// <inheritdoc/>
     protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, AppClaimRequirement requirement, object resource)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         AuthorizationResult result;
 
         if (resource is not IRequiresAuthorization)
         {
-            result = await _authorizationManager.AuthorizeAsync(context.User, requirement);
+            result = await _authorizationManager.AuthorizeAsync(context.User, requirement).ConfigureAwait(false);
             if (result.Succeeded)
             {
                 context.Succeed(requirement);
@@ -34,7 +36,7 @@ public class AppClaimRequirementHandler : AuthorizationHandler<AppClaimRequireme
             return;
         }
 
-        result = await _authorizationManager.AuthorizeAsync(context.User, resource, requirement);
+        result = await _authorizationManager.AuthorizeAsync(context.User, resource, requirement).ConfigureAwait(false);
         if (result.Succeeded)
         {
             context.Succeed(requirement);

--- a/Authorization.Core/AppClaimRequirementProvider.cs
+++ b/Authorization.Core/AppClaimRequirementProvider.cs
@@ -1,47 +1,45 @@
 ﻿using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// IAuthorizationPolicyProvider implementation that supports use of the RequiresClaims authorization attribute
+/// </summary>
+public class AppClaimRequirementProvider : IAuthorizationPolicyProvider
 {
+    private DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
+
     /// <summary>
-    /// IAuthorizationPolicyProvider implementation that supports use of the RequiresClaims authorization attribute
+    /// Creates a new instance of the AppClaimRequirementProvider using the specified AuthorizationOptions.
     /// </summary>
-    public class AppClaimRequirementProvider : IAuthorizationPolicyProvider
+    /// <param name="options">The AuthorizationOptions to be used to initialize the new AppClaimRequirementProvider instance.</param>
+    public AppClaimRequirementProvider(IOptions<AuthorizationOptions> options)
     {
-        private DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
+        FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+    }
 
-        /// <summary>
-        /// Creates a new instance of the AppClaimRequirementProvider using the specified AuthorizationOptions.
-        /// </summary>
-        /// <param name="options">The AuthorizationOptions to be used to initialize the new AppClaimRequirementProvider instance.</param>
-        public AppClaimRequirementProvider(IOptions<AuthorizationOptions> options)
+    /// <inheritdoc />
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync()
+        => FallbackPolicyProvider.GetDefaultPolicyAsync();
+
+    /// <inheritdoc />
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync()
+        => FallbackPolicyProvider.GetFallbackPolicyAsync();
+
+    /// <inheritdoc />
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+    {
+        if (RequiresClaimsAttribute.TryParse(policyName, out RequiresClaimsAttribute? requiresClaimsAttribute))
         {
-            FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+            var policy = new AuthorizationPolicyBuilder();
+            policy.AddRequirements(
+                new AppClaimRequirement(requiresClaimsAttribute.ClaimValues)
+                );
+            return Task.FromResult((AuthorizationPolicy?)policy.Build());
         }
 
-        /// <inheritdoc />
-        public Task<AuthorizationPolicy> GetDefaultPolicyAsync()
-            => FallbackPolicyProvider.GetDefaultPolicyAsync();
-
-        /// <inheritdoc />
-        public Task<AuthorizationPolicy?> GetFallbackPolicyAsync()
-            => FallbackPolicyProvider.GetFallbackPolicyAsync();
-
-        /// <inheritdoc />
-        public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
-        {
-            if (RequiresClaimsAttribute.TryParse(policyName, out RequiresClaimsAttribute? requiresClaimsAttribute))
-            {
-                var policy = new AuthorizationPolicyBuilder();
-                policy.AddRequirements(
-                    new AppClaimRequirement(requiresClaimsAttribute.ClaimValues)
-                    );
-                return Task.FromResult((AuthorizationPolicy?)policy.Build());
-            }
-
-            return FallbackPolicyProvider.GetPolicyAsync(policyName);
-        }
+        return FallbackPolicyProvider.GetPolicyAsync(policyName);
     }
 }

--- a/Authorization.Core/AppClaimRequirementProvider.cs
+++ b/Authorization.Core/AppClaimRequirementProvider.cs
@@ -31,6 +31,8 @@ public class AppClaimRequirementProvider : IAuthorizationPolicyProvider
     /// <inheritdoc />
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
     {
+        ArgumentNullException.ThrowIfNull(policyName);
+
         if (RequiresClaimsAttribute.TryParse(policyName, out RequiresClaimsAttribute? requiresClaimsAttribute))
         {
             var policy = new AuthorizationPolicyBuilder();

--- a/Authorization.Core/Attributes/RequiresClaimsAttribute.cs
+++ b/Authorization.Core/Attributes/RequiresClaimsAttribute.cs
@@ -1,12 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace CRFricke.Authorization.Core.Attributes
 {
     ///<inheritdoc/>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public class RequiresClaimsAttribute : AuthorizeAttribute
+    public sealed class RequiresClaimsAttribute : AuthorizeAttribute
     {
         internal const string PolicyDelimeter = ": ";
         internal const string PolicyHeader = "RequiresClaims";

--- a/Authorization.Core/Attributes/RestrictedClaimAttribute.cs
+++ b/Authorization.Core/Attributes/RestrictedClaimAttribute.cs
@@ -9,7 +9,7 @@ namespace CRFricke.Authorization.Core.Attributes
     /// This attribute is used to prevent system entities (e.g. the Administrator user or role) from being deleted.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
-    public class RestrictedClaimAttribute : Attribute
+    public sealed class RestrictedClaimAttribute : Attribute
     {
     }
 }

--- a/Authorization.Core/AuthRoleExtensions.cs
+++ b/Authorization.Core/AuthRoleExtensions.cs
@@ -8,76 +8,62 @@ namespace CRFricke.Authorization.Core;
 /// </summary>
 public static class AuthRoleExtensions
 {
-    /// <summary>
-    /// Sets the Claims collection of this <see cref="AuthRole"/> object.
-    /// </summary>
-    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-    /// <param name="claims">The claim values to be assigned to this application role.</param>
-    public static TRole SetClaims<TRole>(this TRole role, IEnumerable<string> claims) where TRole : AuthRole
+    extension(AuthRole role)
     {
-        return SetClaims(role, [.. claims]);
-    }
-
-    /// <summary>
-    /// Sets the Claims collection of this <see cref="AuthRole"/> object.
-    /// </summary>
-    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-    /// <param name="claims">The claim values to be assigned to this application role.</param>
-    public static TRole SetClaims<TRole>(this TRole role, params string[] claims) where TRole : AuthRole
-    {
-        role.Claims.Clear();
-
-        foreach (var claim in claims)
+        /// <summary>
+        /// Sets the Claims collection of this <see cref="AuthRole"/> object.
+        /// </summary>
+        /// <param name="claims">The claim values to be assigned to this application role.</param>
+        public TRole SetClaims<TRole>(params IEnumerable<string> claims) where TRole : AuthRole
         {
-            role.Claims.Add(SysClaims.CreateRoleClaim(roleId: role.Id, claimValue: claim));
+            ArgumentNullException.ThrowIfNull(claims);
+
+            var claimsArray = claims as string[] ?? [.. claims];
+
+            role.Claims.Clear();
+
+            foreach (var claim in claimsArray)
+            {
+                role.Claims.Add(SysClaims.CreateRoleClaim(roleId: role.Id, claimValue: claim));
+            }
+
+            return (TRole)role;
         }
 
-        return role;
-    }
-
-    /// <summary>
-    /// Updates the Claims collection using the specified claim values.
-    /// </summary>
-    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-    /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
-    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-    public static bool UpdateClaims(this AuthRole role, IEnumerable<string> assignedClaims)
-    {
-        return UpdateClaims(role, [.. assignedClaims]);
-    }
-
-    /// <summary>
-    /// Updates the Claims collection using the specified claim values.
-    /// </summary>
-    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-    /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
-    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-    public static bool UpdateClaims(this AuthRole role, params string[] assignedClaims)
-    {
-        var oldClaims =
-            from claim in role.Claims
-            select claim.ClaimValue;
-
-        // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
-        // execution, which prevents an InvalidOperationException while enumerating the result sets.
-        var claimsInCommon = oldClaims.Intersect(assignedClaims);
-        var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
-        var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
-
-        foreach (var claim in claimsToRemove)
+        /// <summary>
+        /// Updates the Claims collection using the specified claim values.
+        /// </summary>
+        /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
+        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+        public bool UpdateClaims(params IEnumerable<string> assignedClaims)
         {
-            role.Claims.Remove(
-                role.Claims.Where(c => c.ClaimValue == claim).First()
-                );
-        }
+            var claimsArray = assignedClaims as string[] ?? [.. assignedClaims];
 
-        foreach (var claim in claimsToAdd)
-        {
-            role.Claims.Add(
-                new IdentityRoleClaim<string> { RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = claim }
-                );
-        }
+            var oldClaims = (
+                from claim in role.Claims
+                select claim.ClaimValue).ToArray();
 
-        return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
+            // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
+            // execution, which prevents an InvalidOperationException while enumerating the result sets.
+            var claimsInCommon = oldClaims.Intersect(claimsArray).ToArray();
+            var claimsToAdd = claimsArray.Except(claimsInCommon).ToArray();
+            var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
+
+            foreach (var claim in claimsToRemove)
+            {
+                role.Claims.Remove(
+                    role.Claims.Where(c => c.ClaimValue == claim).First()
+                    );
+            }
+
+            foreach (var claim in claimsToAdd)
+            {
+                role.Claims.Add(
+                    new IdentityRoleClaim<string> { RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = claim }
+                    );
+            }
+
+            return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
+        }
     }
 }

--- a/Authorization.Core/AuthRoleExtensions.cs
+++ b/Authorization.Core/AuthRoleExtensions.cs
@@ -1,86 +1,83 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.AspNetCore.Identity;
-using System.Collections.Generic;
-using System.Linq;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Provides extension methods for manipulating <see cref="AuthRole"/> objects.
+/// </summary>
+public static class AuthRoleExtensions
 {
     /// <summary>
-    /// Provides extension methods for manipulating <see cref="AuthRole"/> objects.
+    /// Sets the Claims collection of this <see cref="AuthRole"/> object.
     /// </summary>
-    public static class AuthRoleExtensions
+    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
+    /// <param name="claims">The claim values to be assigned to this application role.</param>
+    public static TRole SetClaims<TRole>(this TRole role, IEnumerable<string> claims) where TRole : AuthRole
     {
-        /// <summary>
-        /// Sets the Claims collection of this <see cref="AuthRole"/> object.
-        /// </summary>
-        /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-        /// <param name="claims">The claim values to be assigned to this application role.</param>
-        public static TRole SetClaims<TRole>(this TRole role, IEnumerable<string> claims) where TRole : AuthRole
+        return SetClaims(role, [.. claims]);
+    }
+
+    /// <summary>
+    /// Sets the Claims collection of this <see cref="AuthRole"/> object.
+    /// </summary>
+    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
+    /// <param name="claims">The claim values to be assigned to this application role.</param>
+    public static TRole SetClaims<TRole>(this TRole role, params string[] claims) where TRole : AuthRole
+    {
+        role.Claims.Clear();
+
+        foreach (var claim in claims)
         {
-            return SetClaims(role, claims.ToArray());
+            role.Claims.Add(SysClaims.CreateRoleClaim(roleId: role.Id, claimValue: claim));
         }
 
-        /// <summary>
-        /// Sets the Claims collection of this <see cref="AuthRole"/> object.
-        /// </summary>
-        /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-        /// <param name="claims">The claim values to be assigned to this application role.</param>
-        public static TRole SetClaims<TRole>(this TRole role, params string[] claims) where TRole : AuthRole
+        return role;
+    }
+
+    /// <summary>
+    /// Updates the Claims collection using the specified claim values.
+    /// </summary>
+    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
+    /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
+    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+    public static bool UpdateClaims(this AuthRole role, IEnumerable<string> assignedClaims)
+    {
+        return UpdateClaims(role, [.. assignedClaims]);
+    }
+
+    /// <summary>
+    /// Updates the Claims collection using the specified claim values.
+    /// </summary>
+    /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
+    /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
+    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+    public static bool UpdateClaims(this AuthRole role, params string[] assignedClaims)
+    {
+        var oldClaims =
+            from claim in role.Claims
+            select claim.ClaimValue;
+
+        // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
+        // execution, which prevents an InvalidOperationException while enumerating the result sets.
+        var claimsInCommon = oldClaims.Intersect(assignedClaims);
+        var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
+        var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
+
+        foreach (var claim in claimsToRemove)
         {
-            role.Claims.Clear();
-
-            foreach (var claim in claims)
-            {
-                role.Claims.Add(SysClaims.CreateRoleClaim(roleId: role.Id, claimValue: claim));
-            }
-
-            return role;
+            role.Claims.Remove(
+                role.Claims.Where(c => c.ClaimValue == claim).First()
+                );
         }
 
-        /// <summary>
-        /// Updates the Claims collection using the specified claim values.
-        /// </summary>
-        /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-        /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
-        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-        public static bool UpdateClaims(this AuthRole role, IEnumerable<string> assignedClaims)
+        foreach (var claim in claimsToAdd)
         {
-            return UpdateClaims(role, assignedClaims.ToArray());
+            role.Claims.Add(
+                new IdentityRoleClaim<string> { RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = claim }
+                );
         }
 
-        /// <summary>
-        /// Updates the Claims collection using the specified claim values.
-        /// </summary>
-        /// <param name="role">The <see cref="AuthRole"/> whose Claims collection is to be updated.</param>
-        /// <param name="assignedClaims">The claim values to be assigned to this application role.</param>
-        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-        public static bool UpdateClaims(this AuthRole role, params string[] assignedClaims)
-        {
-            var oldClaims =
-                from claim in role.Claims
-                select claim.ClaimValue;
-
-            // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
-            // execution, which prevents an InvalidOperationException while enumerating the result sets.
-            var claimsInCommon = oldClaims.Intersect(assignedClaims);
-            var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
-            var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
-
-            foreach (var claim in claimsToRemove)
-            {
-                role.Claims.Remove(
-                    role.Claims.Where(c => c.ClaimValue == claim).First()
-                    );
-            }
-
-            foreach (var claim in claimsToAdd)
-            {
-                role.Claims.Add(
-                    new IdentityRoleClaim<string> { RoleId = role.Id, ClaimType = SysClaims.ClaimType, ClaimValue = claim }
-                    );
-            }
-
-            return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
-        }
+        return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
     }
 }

--- a/Authorization.Core/AuthUserExtensions.cs
+++ b/Authorization.Core/AuthUserExtensions.cs
@@ -9,78 +9,63 @@ namespace CRFricke.Authorization.Core;
 /// </summary>
 public static class AuthUserExtensions
 {
-    /// <summary>
-    /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
-    /// </summary>
-    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-    /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
-    /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
-    public static TUser SetClaims<TUser>(this TUser user, IEnumerable<string> claims) where TUser : AuthUser
+    extension(AuthUser user)
     {
-        return SetClaims(user, [.. claims]);
-    }
-
-    /// <summary>
-    /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
-    /// </summary>
-    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-    /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
-    /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
-    public static TUser SetClaims<TUser>(this TUser user, params string[] claims) where TUser : AuthUser
-    {
-        user.Claims.Clear();
-
-        foreach (var claim in claims)
+        /// <summary>
+        /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
+        /// </summary>
+        /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
+        /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
+        public TUser SetClaims<TUser>(params IEnumerable<string> claims) where TUser : AuthUser
         {
-            user.Claims.Add(SysClaims.CreateUserClaim(userId: user.Id, claimValue: claim));
+            ArgumentNullException.ThrowIfNull(claims);
+
+            var claimsArray = claims as string[] ?? [.. claims];
+
+            user.Claims.Clear();
+
+            foreach (var claim in claimsArray)
+            {
+                user.Claims.Add(SysClaims.CreateUserClaim(userId: user.Id, claimValue: claim));
+            }
+
+            return (TUser)user;
         }
 
-        return user;
-    }
-
-    /// <summary>
-    /// Updates the Claims collection using the specified claim values.
-    /// </summary>
-    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-    /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
-    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-    public static bool UpdateClaims(this AuthUser user, IEnumerable<string> assignedClaims)
-    {
-        return UpdateClaims(user, [.. assignedClaims]);
-    }
-
-    /// <summary>
-    /// Updates the Claims collection using the specified claim values.
-    /// </summary>
-    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-    /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
-    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-    public static bool UpdateClaims(this AuthUser user, params string[] assignedClaims)
-    {
-        var oldClaims =
-            from claim in user.Claims
-            select claim.ClaimValue;
-
-        // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
-        // execution, which prevents an InvalidOperationException while enumerating the result sets.
-        var claimsInCommon = oldClaims.Intersect(assignedClaims);
-        var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
-        var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
-
-        foreach (var claim in claimsToRemove)
+        /// <summary>
+        /// Updates the Claims collection using the specified claim values.
+        /// </summary>
+        /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
+        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+        public bool UpdateClaims(params IEnumerable<string> assignedClaims)
         {
-            user.Claims.Remove(
-                user.Claims.Where(c => c.ClaimValue == claim).First()
-                );
-        }
+            var claimsArray = assignedClaims as string[] ?? [.. assignedClaims];
 
-        foreach (var claim in claimsToAdd)
-        {
-            user.Claims.Add(
-                new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = claim }
-                );
-        }
+            var oldClaims = (
+                from claim in user.Claims
+                select claim.ClaimValue).ToArray();
 
-        return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
+            // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
+            // execution, which prevents an InvalidOperationException while enumerating the result sets.
+            var claimsInCommon = oldClaims.Intersect(claimsArray).ToArray();
+            var claimsToAdd = claimsArray.Except(claimsInCommon).ToArray();
+            var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
+
+            foreach (var claim in claimsToRemove)
+            {
+                user.Claims.Remove(
+                    user.Claims.Where(c => c.ClaimValue == claim).First()
+                    );
+            }
+
+            foreach (var claim in claimsToAdd)
+            {
+                user.Claims.Add(
+                    new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = claim }
+                    );
+            }
+
+            return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
+        }
     }
 }

--- a/Authorization.Core/AuthUserExtensions.cs
+++ b/Authorization.Core/AuthUserExtensions.cs
@@ -1,89 +1,86 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.AspNetCore.Identity;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Provides extension methods for manipulating <see cref="AuthUser"/> objects.
+/// </summary>
+public static class AuthUserExtensions
 {
     /// <summary>
-    /// Provides extension methods for manipulating <see cref="AuthUser"/> objects.
+    /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
     /// </summary>
-    public static class AuthUserExtensions
+    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
+    /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
+    /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
+    public static TUser SetClaims<TUser>(this TUser user, IEnumerable<string> claims) where TUser : AuthUser
     {
-        /// <summary>
-        /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
-        /// </summary>
-        /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-        /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
-        /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
-        public static TUser SetClaims<TUser>(this TUser user, IEnumerable<string> claims) where TUser : AuthUser
+        return SetClaims(user, [.. claims]);
+    }
+
+    /// <summary>
+    /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
+    /// </summary>
+    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
+    /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
+    /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
+    public static TUser SetClaims<TUser>(this TUser user, params string[] claims) where TUser : AuthUser
+    {
+        user.Claims.Clear();
+
+        foreach (var claim in claims)
         {
-            return SetClaims(user, claims.ToArray());
+            user.Claims.Add(SysClaims.CreateUserClaim(userId: user.Id, claimValue: claim));
         }
 
-        /// <summary>
-        /// Sets the Claims collection of this <see cref="AuthUser"/> objects.
-        /// </summary>
-        /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-        /// <param name="claims">The claim values to be assigned to this <see cref="AuthUser"/>.</param>
-        /// <returns>The <typeparamref name="TUser"/>class instance.</returns>
-        public static TUser SetClaims<TUser>(this TUser user, params string[] claims) where TUser : AuthUser
+        return user;
+    }
+
+    /// <summary>
+    /// Updates the Claims collection using the specified claim values.
+    /// </summary>
+    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
+    /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
+    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+    public static bool UpdateClaims(this AuthUser user, IEnumerable<string> assignedClaims)
+    {
+        return UpdateClaims(user, [.. assignedClaims]);
+    }
+
+    /// <summary>
+    /// Updates the Claims collection using the specified claim values.
+    /// </summary>
+    /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
+    /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
+    /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
+    public static bool UpdateClaims(this AuthUser user, params string[] assignedClaims)
+    {
+        var oldClaims =
+            from claim in user.Claims
+            select claim.ClaimValue;
+
+        // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
+        // execution, which prevents an InvalidOperationException while enumerating the result sets.
+        var claimsInCommon = oldClaims.Intersect(assignedClaims);
+        var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
+        var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
+
+        foreach (var claim in claimsToRemove)
         {
-            user.Claims.Clear();
-
-            foreach (var claim in claims)
-            {
-                user.Claims.Add(SysClaims.CreateUserClaim(userId: user.Id, claimValue: claim));
-            }
-
-            return user;
+            user.Claims.Remove(
+                user.Claims.Where(c => c.ClaimValue == claim).First()
+                );
         }
 
-        /// <summary>
-        /// Updates the Claims collection using the specified claim values.
-        /// </summary>
-        /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-        /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
-        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-        public static bool UpdateClaims(this AuthUser user, IEnumerable<string> assignedClaims)
+        foreach (var claim in claimsToAdd)
         {
-            return UpdateClaims(user, assignedClaims.ToArray());
+            user.Claims.Add(
+                new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = claim }
+                );
         }
 
-        /// <summary>
-        /// Updates the Claims collection using the specified claim values.
-        /// </summary>
-        /// <param name="user">The AuthUser <see cref="AuthUser"/> whose Claims collection is to be updated.</param>
-        /// <param name="assignedClaims">The claim values to be assigned to this application user.</param>
-        /// <returns><em>true</em>, if the Claims collection was modified; otherwise, <em>false</em>.</returns>
-        public static bool UpdateClaims(this AuthUser user, params string[] assignedClaims)
-        {
-            var oldClaims =
-                from claim in user.Claims
-                select claim.ClaimValue;
-
-            // Linq doesn't run queries until the results are needed. We use ToArray() below to force query 
-            // execution, which prevents an InvalidOperationException while enumerating the result sets.
-            var claimsInCommon = oldClaims.Intersect(assignedClaims);
-            var claimsToAdd = assignedClaims.Except(claimsInCommon).ToArray();
-            var claimsToRemove = oldClaims.Except(claimsInCommon).ToArray();
-
-            foreach (var claim in claimsToRemove)
-            {
-                user.Claims.Remove(
-                    user.Claims.Where(c => c.ClaimValue == claim).First()
-                    );
-            }
-
-            foreach (var claim in claimsToAdd)
-            {
-                user.Claims.Add(
-                    new IdentityUserClaim<string> { UserId = user.Id, ClaimType = ClaimTypes.Role, ClaimValue = claim }
-                    );
-            }
-
-            return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
-        }
+        return claimsToAdd.Length != 0 || claimsToRemove.Length != 0;
     }
 }

--- a/Authorization.Core/Authorization.Core.csproj
+++ b/Authorization.Core/Authorization.Core.csproj
@@ -1,42 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>CRFricke.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>CRFricke.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
-    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors>Chuck Fricke</Authors>
-    <Company>Fricke Consulting</Company>
-    <Copyright>Copyright © Chuck Fricke $([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <Description>Extends ASP.NET Core Identity to provide authorization based on entity CRUD permission claims (e.g. "User.Create", "User.Read", "User.Update", "User.Delete", and "User.List").</Description>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/CRFricke/Authorization.Core</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>aspnetcore, identity, membership, authorization</PackageTags>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-  </PropertyGroup>
-
-  <!-- For 'push' workflow, we embed the symbol package in the DLL and push the nupkg to github.com -->
-  <PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'push'">
-    <DebugType>embedded</DebugType>
-  </PropertyGroup>
-
-  <!-- For 'release' workflow, we create a separate symbol package and push both to nuget.org -->
-  <PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'release'">
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
-  <!-- To get a "deterministic build" for our NuGet package: -->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Authorization.Core/AuthorizationFailure.cs
+++ b/Authorization.Core/AuthorizationFailure.cs
@@ -10,7 +10,7 @@ public class AuthorizationFailure
     /// <summary>
     /// Defines the reason codes that can be returned as a <see cref="FailureReason"/>.
     /// </summary>
-    public class Reason
+    public static class Reason
     {
         /// <summary>
         /// The user is not authorized (is missing one or more required claims). 
@@ -47,7 +47,7 @@ public class AuthorizationFailure
     /// <summary>
     /// The missing claims that caused authorization to fail.
     /// </summary>
-    public string[]? FailingClaims { get; private set; }
+    public IReadOnlyCollection<string>? FailingClaims { get; private set; }
 
     /// <summary>
     /// Returns a string representing the current <see cref="AuthorizationFailure"/> object.

--- a/Authorization.Core/AuthorizationFailure.cs
+++ b/Authorization.Core/AuthorizationFailure.cs
@@ -1,94 +1,92 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿namespace CRFricke.Authorization.Core;
 
-namespace CRFricke.Authorization.Core
+#pragma warning disable CA1034 // Nested types should not be visible
+
+/// <summary>
+/// Describes the failure of an authorization request.
+/// </summary>
+public class AuthorizationFailure
 {
     /// <summary>
-    /// Describes the failure of an authorization request.
+    /// Defines the reason codes that can be returned as a <see cref="FailureReason"/>.
     /// </summary>
-    public class AuthorizationFailure
+    public class Reason
     {
         /// <summary>
-        /// Defines the reason codes that can be returned as a <see cref="FailureReason"/>.
+        /// The user is not authorized (is missing one or more required claims). 
         /// </summary>
-        public class Reason
-        {
-            /// <summary>
-            /// The user is not authorized (is missing one or more required claims). 
-            /// </summary>
-            public static readonly string NotAuthorized = "NotAuthorized";
-
-            /// <summary>
-            /// The request would elevate the user's privileges.
-            /// </summary>
-            public static readonly string Elevation = "Elevation";
-
-            /// <summary>
-            /// The current user could not be determined.
-            /// </summary>
-            public static readonly string NoUserId = "NoUserId";
-
-            /// <summary>
-            /// The user is attempting to perform a restricted operation on a system object.
-            /// </summary>
-            public static readonly string SystemObject = "SystemObject";
-        }
+        public static readonly string NotAuthorized = "NotAuthorized";
 
         /// <summary>
-        /// Creates a new instance of the AuthorizationFailure class with default values.
+        /// The request would elevate the user's privileges.
         /// </summary>
-        public AuthorizationFailure()
-        { }
+        public static readonly string Elevation = "Elevation";
 
         /// <summary>
-        /// A code that describes the reason for the failure.
+        /// The current user could not be determined.
         /// </summary>
-        public string? FailureReason { get; private set; }
+        public static readonly string NoUserId = "NoUserId";
 
         /// <summary>
-        /// The missing claims that caused authorization to fail.
+        /// The user is attempting to perform a restricted operation on a system object.
         /// </summary>
-        public string[]? FailingClaims { get; private set; }
-
-        /// <summary>
-        /// Returns a string representing the current <see cref="AuthorizationFailure"/> object.
-        /// </summary>
-        /// <returns>A string representing the current <see cref="AuthorizationFailure"/> object.</returns>
-        public override string ToString()
-        {
-            return FailureReason ?? nameof(AuthorizationResult.Failed);
-        }
-
-        /// <summary>
-        /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "NotAuthorized".
-        /// </summary>
-        /// <param name="failingClaims">The claims that prevented authorization.</param>
-        /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "NotAuthorized".</returns>
-        public static AuthorizationFailure NotAuthorized(IEnumerable<string>? failingClaims = null)
-            => new() { FailureReason = Reason.NotAuthorized, FailingClaims = failingClaims?.ToArray() };
-
-        /// <summary>
-        /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "Elevation".
-        /// </summary>
-        /// <param name="failingClaims">The claims that prevented authorization.</param>
-        /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "Elevation".</returns>
-        public static AuthorizationFailure Elevation(IEnumerable<string>? failingClaims = null)
-            => new() { FailureReason = Reason.Elevation, FailingClaims = failingClaims?.ToArray() };
-
-        /// <summary>
-        /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "NoUserId".
-        /// </summary>
-        /// <param name="failingClaims">The claims that prevented authorization.</param>
-        /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "NoUserId".</returns>
-        public static AuthorizationFailure NoUserId(IEnumerable<string>? failingClaims = null)
-            => new() { FailureReason = Reason.NoUserId, FailingClaims = failingClaims?.ToArray() };
-
-        /// <summary>
-        /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "SystemObject".
-        /// </summary>
-        /// <param name="failingClaims">The claims that prevented authorization.</param>
-        /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "SystemObject".</returns>
-        public static AuthorizationFailure SystemObject(IEnumerable<string>? failingClaims = null)
-            => new() { FailureReason = Reason.SystemObject, FailingClaims = failingClaims?.ToArray() };
+        public static readonly string SystemObject = "SystemObject";
     }
+
+    /// <summary>
+    /// Creates a new instance of the AuthorizationFailure class with default values.
+    /// </summary>
+    public AuthorizationFailure()
+    { }
+
+    /// <summary>
+    /// A code that describes the reason for the failure.
+    /// </summary>
+    public string? FailureReason { get; private set; }
+
+    /// <summary>
+    /// The missing claims that caused authorization to fail.
+    /// </summary>
+    public string[]? FailingClaims { get; private set; }
+
+    /// <summary>
+    /// Returns a string representing the current <see cref="AuthorizationFailure"/> object.
+    /// </summary>
+    /// <returns>A string representing the current <see cref="AuthorizationFailure"/> object.</returns>
+    public override string ToString()
+    {
+        return FailureReason ?? nameof(AuthorizationResult.Failed);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "NotAuthorized".
+    /// </summary>
+    /// <param name="failingClaims">The claims that prevented authorization.</param>
+    /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "NotAuthorized".</returns>
+    public static AuthorizationFailure NotAuthorized(IEnumerable<string>? failingClaims = null)
+        => new() { FailureReason = Reason.NotAuthorized, FailingClaims = failingClaims?.ToArray() };
+
+    /// <summary>
+    /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "Elevation".
+    /// </summary>
+    /// <param name="failingClaims">The claims that prevented authorization.</param>
+    /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "Elevation".</returns>
+    public static AuthorizationFailure Elevation(IEnumerable<string>? failingClaims = null)
+        => new() { FailureReason = Reason.Elevation, FailingClaims = failingClaims?.ToArray() };
+
+    /// <summary>
+    /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "NoUserId".
+    /// </summary>
+    /// <param name="failingClaims">The claims that prevented authorization.</param>
+    /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "NoUserId".</returns>
+    public static AuthorizationFailure NoUserId(IEnumerable<string>? failingClaims = null)
+        => new() { FailureReason = Reason.NoUserId, FailingClaims = failingClaims?.ToArray() };
+
+    /// <summary>
+    /// Returns a new <see cref="AuthorizationFailure"/> object with a failure reason of "SystemObject".
+    /// </summary>
+    /// <param name="failingClaims">The claims that prevented authorization.</param>
+    /// <returns>A new <see cref="AuthorizationFailure"/> object with a failure reason of "SystemObject".</returns>
+    public static AuthorizationFailure SystemObject(IEnumerable<string>? failingClaims = null)
+        => new() { FailureReason = Reason.SystemObject, FailingClaims = failingClaims?.ToArray() };
 }

--- a/Authorization.Core/AuthorizationManager.cs
+++ b/Authorization.Core/AuthorizationManager.cs
@@ -151,12 +151,12 @@ public sealed class AuthorizationManager<
     /// <summary>
     /// Returns a list of all claims defined by the application.
     /// </summary>
-    List<string> IAuthorizationManager.DefinedClaims => DefinedClaims;
+    IReadOnlyCollection<string> IAuthorizationManager.DefinedClaims => DefinedClaims;
 
     /// <summary>
     /// Returns a list of all Guids defined by the application.
     /// </summary>
-    List<string> IAuthorizationManager.DefinedGuids => DefinedGuids;
+    IReadOnlyCollection<string> IAuthorizationManager.DefinedGuids => DefinedGuids;
 
 
 
@@ -174,7 +174,7 @@ public sealed class AuthorizationManager<
     {
         if (resource == null)
         {
-            return await AuthorizeAsync(principal, claimRequirement);
+            return await AuthorizeAsync(principal, claimRequirement).ConfigureAwait(false);
         }
 
         ArgumentNullException.ThrowIfNull(principal);
@@ -196,8 +196,8 @@ public sealed class AuthorizationManager<
         if (DefinedGuids.Contains(raResource.Id))
         {
             // Yes - fail requests for restricted claims
-            var failedClaims = claimRequirement.ClaimValues.Intersect(RestrictedClaims);
-            if (failedClaims.Any())
+            var failedClaims = claimRequirement.ClaimValues.Intersect(RestrictedClaims).ToList();
+            if (failedClaims.Count != 0)
             {
                 var userName = principal.UserName();
                 var resourceType = resource.GetType().Name;
@@ -211,7 +211,7 @@ public sealed class AuthorizationManager<
             }
         }
 
-        var result = await AuthorizeInternalAsync(principal, claimRequirement);
+        var result = await AuthorizeInternalAsync(principal, claimRequirement).ConfigureAwait(false);
         if (!result.Succeeded)
         {
             return result;
@@ -226,7 +226,7 @@ public sealed class AuthorizationManager<
         {
             return await handler.HandleAsync(
                 new ResourceAuthorizationHandlerContext(this, raResource, principal, claimRequirement)
-                );
+                ).ConfigureAwait(false);
         }
 
         return result;
@@ -255,7 +255,7 @@ public sealed class AuthorizationManager<
             return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
         }
 
-        return await AuthorizeInternalAsync(principal, claimRequirement);
+        return await AuthorizeInternalAsync(principal, claimRequirement).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -270,7 +270,7 @@ public sealed class AuthorizationManager<
     {
         var userId = principal.UserId() ?? throw new InvalidOperationException("Specified ClaimsPrincipal does not have a 'NameIdentifier' Claim.");
 
-        var principalRoles = await GetUserRolesAsync(userId);
+        var principalRoles = await GetUserRolesAsync(userId).ConfigureAwait(false);
         if (principalRoles.Contains(SysGuids.Role.Administrator))
         {
             _logger.LogDebug(
@@ -280,7 +280,7 @@ public sealed class AuthorizationManager<
             return AuthorizationResult.Success();
         }
 
-        HashSet<string> principalClaims = await GetRoleClaimsAsync(principalRoles);
+        HashSet<string> principalClaims = await GetRoleClaimsAsync(principalRoles).ConfigureAwait(false);
         if (claimRequirement.ClaimValues.IsSubsetOf(principalClaims))
         {
             _logger.LogDebug(
@@ -306,7 +306,7 @@ public sealed class AuthorizationManager<
 
         foreach (var roleId in roleIds)
         {
-            claimHash.UnionWith(await GetRoleClaimsAsync(roleId));
+            claimHash.UnionWith(await GetRoleClaimsAsync(roleId).ConfigureAwait(false));
         }
 
         return claimHash;
@@ -331,7 +331,7 @@ public sealed class AuthorizationManager<
                 dbContext.Set<IdentityRoleClaim<string>>()
                 .Where(rc => rc.RoleId == roleId && rc.ClaimType == SysClaims.ClaimType)
                 .Select(rc => rc.ClaimValue!)
-                .ToArrayAsync()
+                .ToArrayAsync().ConfigureAwait(false)
                 ).ToHashSet();
 
             roleClaimCache.Set(
@@ -363,7 +363,7 @@ public sealed class AuthorizationManager<
             from ar in dbContext.Set<TRole>()
             where roleNames.Contains(ar.Name)
             select ar.Id
-            ).ToArrayAsync()).ToHashSet();
+            ).ToArrayAsync().ConfigureAwait(false)).ToHashSet();
     }
 
     /// <summary>
@@ -387,7 +387,7 @@ public sealed class AuthorizationManager<
                 join ar in dbContext.Set<TRole>() on uc.ClaimValue equals ar.Id
                 where uc.UserId == userId && uc.ClaimType == ClaimTypes.Role
                 select ar.Id
-                ).ToArrayAsync()).ToHashSet();
+                ).ToArrayAsync().ConfigureAwait(false)).ToHashSet();
 
             userRoleCache.Set(
                 userId, hashSet,
@@ -408,7 +408,7 @@ public sealed class AuthorizationManager<
     /// </returns>
     public async Task<bool> IsAuthorizedAsync(ClaimsPrincipal principal, params string[] requiredClaims)
     {
-        var result = await AuthorizeAsync(principal, new AppClaimRequirement(requiredClaims));
+        var result = await AuthorizeAsync(principal, new AppClaimRequirement(requiredClaims)).ConfigureAwait(false);
         return result.Succeeded;
     }
 

--- a/Authorization.Core/AuthorizationManager.cs
+++ b/Authorization.Core/AuthorizationManager.cs
@@ -179,14 +179,14 @@ public sealed class AuthorizationManager<
 
         ArgumentNullException.ThrowIfNull(principal);
         ArgumentNullException.ThrowIfNull(claimRequirement);
+
         if (resource is not IRequiresAuthorization raResource)
             throw new ArgumentException($"Argument does not implement {nameof(IRequiresAuthorization)} interface.", nameof(resource));
 
         var principalId = principal.UserId();
         if (principalId == null)
         {
-            _logger.LogDebug(
-                "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
+            _logger.LogClaimRequirementNotMetNoUserId(
                 nameof(AppClaimRequirement), claimRequirement, principal.UserName()
                 );
             return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
@@ -203,9 +203,8 @@ public sealed class AuthorizationManager<
                 var resourceType = resource.GetType().Name;
                 var failedClaim = failedClaims.First();
 
-                _logger.LogInformation(
-                    "{ClassName} of \"{Claim}\" for {ResourceType} '{ObjectName}' not met by '{UserName}' - restricted operation on system User or Role.",
-                    nameof(AppClaimRequirement), failedClaim, resourceType, raResource.Name, userName
+                _logger.LogClaimRequirementNotMetSystemObject(
+                    nameof(AppClaimRequirement), failedClaim, resourceType, raResource.Name!, userName
                     );
                 return AuthorizationResult.SystemObject(failedClaims);
             }
@@ -248,8 +247,7 @@ public sealed class AuthorizationManager<
         var userId = principal.UserId();
         if (userId == null)
         {
-            _logger.LogDebug(
-                "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
+            _logger.LogClaimRequirementNotMetNoUserId(
                 nameof(AppClaimRequirement), claimRequirement, principal.UserName()
                 );
             return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
@@ -273,8 +271,7 @@ public sealed class AuthorizationManager<
         var principalRoles = await GetUserRolesAsync(userId).ConfigureAwait(false);
         if (principalRoles.Contains(SysGuids.Role.Administrator))
         {
-            _logger.LogDebug(
-                "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}' via {RoleName} role.",
+            _logger.LogClaimRequirementMetViaAdministrator(
                 nameof(AppClaimRequirement), claimRequirement, principal.UserName(), nameof(SysGuids.Role.Administrator)
                 );
             return AuthorizationResult.Success();
@@ -283,8 +280,7 @@ public sealed class AuthorizationManager<
         HashSet<string> principalClaims = await GetRoleClaimsAsync(principalRoles).ConfigureAwait(false);
         if (claimRequirement.ClaimValues.IsSubsetOf(principalClaims))
         {
-            _logger.LogDebug(
-                "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}'.",
+            _logger.LogClaimRequirementMet(
                 nameof(AppClaimRequirement), claimRequirement, principal.UserName()
                 );
             return AuthorizationResult.Success();

--- a/Authorization.Core/AuthorizationManager.cs
+++ b/Authorization.Core/AuthorizationManager.cs
@@ -6,452 +6,447 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Extends ASP.NET Core Identity to provide authorization based on entity CRUD permission claims
+/// (e.g. "User.Create", "User.Read", "User.Update", "User.Delete", and "User.List").
+/// </summary>
+/// <typeparam name="TUser">The <see cref="Type"/> of user objects. The Type must be or extend from <see cref="AuthUser"/>.</typeparam>
+/// <typeparam name="TRole">The <see cref="Type"/> of role objects. The Type must be or extend from <see cref="AuthRole"/>.</typeparam>
+public sealed class AuthorizationManager<
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole> : IAuthorizationManager, IAuthorizationServices
+    where TUser : AuthUser
+    where TRole : AuthRole
 {
     /// <summary>
-    /// Extends ASP.NET Core Identity to provide authorization based on entity CRUD permission claims
-    /// (e.g. "User.Create", "User.Read", "User.Update", "User.Delete", and "User.List").
+    /// Initializes the static properties of the class.
     /// </summary>
-    /// <typeparam name="TUser">The <see cref="Type"/> of user objects. The Type must be or extend from <see cref="AuthUser"/>.</typeparam>
-    /// <typeparam name="TRole">The <see cref="Type"/> of role objects. The Type must be or extend from <see cref="AuthRole"/>.</typeparam>
-    public sealed class AuthorizationManager<
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole> : IAuthorizationManager, IAuthorizationServices
-        where TUser : AuthUser
-        where TRole : AuthRole
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode, GetReferencedAssemblies()", Justification = "Only looking for assemblies that use AuthorizationManager.")]
+    static AuthorizationManager()
     {
-        /// <summary>
-        /// Initializes the static properties of the class.
-        /// </summary>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode, GetReferencedAssemblies()", Justification = "Only looking for assemblies that use AuthorizationManager.")]
-        static AuthorizationManager()
-        {
-            Assembly thisAssembly = typeof(AuthorizationManager<TUser, TRole>).Assembly;
-            string assemblyName = thisAssembly.GetName().Name!;
+        Assembly thisAssembly = typeof(AuthorizationManager<TUser, TRole>).Assembly;
+        string assemblyName = thisAssembly.GetName().Name!;
 
-            List<Assembly> assemblies =
-            [
-                thisAssembly,
-                .. AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => !a.IsDynamic)   // Ignore Mocked assemblies during testing (GetExportedTypes() throws exception)
-                    .Where(a => a.GetReferencedAssemblies().Any(an => an.Name == assemblyName))
+        List<Assembly> assemblies =
+        [
+            thisAssembly,
+            .. AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic)   // Ignore Mocked assemblies during testing (GetExportedTypes() throws exception)
+                .Where(a => a.GetReferencedAssemblies().Any(an => an.Name == assemblyName))
 ,
-            ];
+        ];
 
-            LoadSystemClaims(assemblies);
-            LoadSystemGuids(assemblies);
-        }
-
-        /// <summary>
-        /// Loads the Claims that are installed by the application.
-        /// </summary>
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SysClaims))]
-        [RequiresUnreferencedCode("Types that implement IDefinesClaims might be removed if application is trimmed.")]
-        private static void LoadSystemClaims(List<Assembly> assemblies)
-        {
-            List<IDefinesClaims> claimClasses = [];
-
-            // Load all classes that implement IDefinesClaims interface.
-            foreach (Assembly assembly in assemblies)
-            {
-                claimClasses.AddRange(
-                    assembly.GetExportedTypes()
-                        .Where(t => typeof(IDefinesClaims).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
-                        .Select(Activator.CreateInstance).Cast<IDefinesClaims>()
-                    );
-            }
-
-            // Now retrieve the Claims defined in each class
-            foreach (var claimClass in claimClasses)
-            {
-                DefinedClaims.AddRange(claimClass.DefinedClaims);
-
-                // Save any claims that are marked with the RestrictedClaim attribute
-                RestrictedClaims.AddRange(
-                    from FieldInfo fi in claimClass.GetType().GetFields()
-                    where Attribute.IsDefined(fi, typeof(RestrictedClaimAttribute))
-                    let claim = fi.GetRawConstantValue() as string
-                    where claim != null
-                    select claim
-                    );
-            }
-        }
-
-        /// <summary>
-        /// Loads the GUIDs of the entities installed by the application.
-        /// </summary>
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SysGuids))]
-        [RequiresUnreferencedCode("Types that implement IDefinesGuids might be removed if application is trimmed.")]
-        private static void LoadSystemGuids(List<Assembly> assemblies)
-        {
-            List<IDefinesGuids> guidClasses = [];
-
-            // Load all classes that implement IDefinesGuids interface.
-            foreach (Assembly assembly in assemblies)
-            {
-                guidClasses.AddRange(
-                    assembly.GetExportedTypes()
-                        .Where(t => typeof(IDefinesGuids).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
-                        .Select(Activator.CreateInstance).Cast<IDefinesGuids>()
-                    );
-            }
-
-            // Now load the GUIDs defined in each class
-            foreach (var guidClass in guidClasses)
-            {
-                DefinedGuids.AddRange(guidClass.DefinedGuids);
-            }
-        }
-
-
-        /// <summary>
-        /// Contains the Claims that are restricted by the application.
-        /// </summary>
-        private static List<string> RestrictedClaims { get; } = [];
-
-        /// <summary>
-        /// Contains the application Claims installed by the application.
-        /// </summary>
-        private static List<string> DefinedClaims { get; } = [];
-
-        /// <summary>
-        /// Contains the GUIDs of the entities installed by the application.
-        /// </summary>
-        private static List<string> DefinedGuids { get; } = [];
-
-
-        private readonly IServiceProvider _serviceProvider;
-        private readonly ILogger<AuthorizationManager> _logger;
-
-
-        /// <summary>
-        /// Internal constructor for testing framework.
-        /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal AuthorizationManager()
-        { }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-
-        /// <summary>
-        /// Creates a new instance of the AuthorizationManager class using the specified parameters.
-        /// </summary>
-        /// <param name="serviceProvider">The ServiceProvider to be used to access required services.</param>
-        /// <param name="logger">The logger to be used for logging.</param>
-        public AuthorizationManager(IServiceProvider serviceProvider, ILogger<AuthorizationManager> logger)
-        {
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
-
-
-        /// <summary>
-        /// Returns a list of all claims defined by the application.
-        /// </summary>
-        List<string> IAuthorizationManager.DefinedClaims => DefinedClaims;
-
-        /// <summary>
-        /// Returns a list of all Guids defined by the application.
-        /// </summary>
-        List<string> IAuthorizationManager.DefinedGuids => DefinedGuids;
-
-
-
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/> 
-        /// for the specified <paramref name="resource"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
-        /// <param name="resource">The resource to be tested against.</param>
-        /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
-        /// <returns>
-        /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </returns>
-        public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, object resource, AppClaimRequirement claimRequirement)
-        {
-            if (resource == null)
-            {
-                return await AuthorizeAsync(principal, claimRequirement);
-            }
-
-            ArgumentNullException.ThrowIfNull(principal);
-            ArgumentNullException.ThrowIfNull(claimRequirement);
-            if (resource is not IRequiresAuthorization raResource)
-                throw new ArgumentException($"Argument does not implement {nameof(IRequiresAuthorization)} interface.", nameof(resource));
-
-            var principalId = principal.UserId();
-            if (principalId == null)
-            {
-                _logger.LogDebug(
-                    "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
-                    nameof(AppClaimRequirement), claimRequirement, principal.UserName()
-                    );
-                return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
-            }
-
-            // Is this a system User or Role?
-            if (DefinedGuids.Contains(raResource.Id))
-            {
-                // Yes - fail requests for restricted claims
-                var failedClaims = claimRequirement.ClaimValues.Intersect(RestrictedClaims);
-                if (failedClaims.Any())
-                {
-                    var userName = principal.UserName();
-                    var resourceType = resource.GetType().Name;
-                    var failedClaim = failedClaims.First();
-
-                    _logger.LogInformation(
-                        "{ClassName} of \"{Claim}\" for {ResourceType} '{ObjectName}' not met by '{UserName}' - restricted operation on system User or Role.",
-                        nameof(AppClaimRequirement), failedClaim, resourceType, raResource.Name, userName
-                        );
-                    return AuthorizationResult.SystemObject(failedClaims);
-                }
-            }
-
-            var result = await AuthorizeInternalAsync(principal, claimRequirement);
-            if (!result.Succeeded)
-            {
-                return result;
-            }
-
-            // See if there is a IResourceHandler implementation for the resource 
-            var handler = _serviceProvider.GetRequiredService(
-                typeof(IResourceAuthorizationHandler<>).MakeGenericType(resource.GetType())
-                ) as IResourceAuthorizationHandler;
-
-            if (handler is not null)
-            {
-                return await handler.HandleAsync(
-                    new ResourceAuthorizationHandlerContext(this, raResource, principal, claimRequirement)
-                    );
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
-        /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
-        /// <returns>
-        /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </returns>
-        public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement)
-        {
-            ArgumentNullException.ThrowIfNull(principal);
-            ArgumentNullException.ThrowIfNull(claimRequirement);
-
-            var userId = principal.UserId();
-            if (userId == null)
-            {
-                _logger.LogDebug(
-                    "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
-                    nameof(AppClaimRequirement), claimRequirement, principal.UserName()
-                    );
-                return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
-            }
-
-            return await AuthorizeInternalAsync(principal, claimRequirement);
-        }
-
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
-        /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
-        /// <returns>
-        /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </returns>
-        private async Task<AuthorizationResult> AuthorizeInternalAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement)
-        {
-            var userId = principal.UserId() ?? throw new InvalidOperationException("Specified ClaimsPrincipal does not have a 'NameIdentifier' Claim.");
-
-            var principalRoles = await GetUserRolesAsync(userId);
-            if (principalRoles.Contains(SysGuids.Role.Administrator))
-            {
-                _logger.LogDebug(
-                    "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}' via {RoleName} role.",
-                    nameof(AppClaimRequirement), claimRequirement, principal.UserName(), nameof(SysGuids.Role.Administrator)
-                    );
-                return AuthorizationResult.Success();
-            }
-
-            HashSet<string> principalClaims = await GetRoleClaimsAsync(principalRoles);
-            if (claimRequirement.ClaimValues.IsSubsetOf(principalClaims))
-            {
-                _logger.LogDebug(
-                    "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}'.",
-                    nameof(AppClaimRequirement), claimRequirement, principal.UserName()
-                    );
-                return AuthorizationResult.Success();
-            }
-
-            return AuthorizationResult.Failed(
-                claimRequirement.ClaimValues.Except(principalClaims)
-                );
-        }
-
-        /// <summary>
-        /// Returns the claims associated with the specified Roles.
-        /// </summary>
-        /// <param name="roleIds">A HashSet containing the IDs of the Roles whose claims are to be retrieved.</param>
-        /// <returns>A HashSet containing the associated claims.</returns>
-        private async Task<HashSet<string>> GetRoleClaimsAsync(HashSet<string> roleIds)
-        {
-            var claimHash = new HashSet<string>();
-
-            foreach (var roleId in roleIds)
-            {
-                claimHash.UnionWith(await GetRoleClaimsAsync(roleId));
-            }
-
-            return claimHash;
-        }
-
-        /// <summary>
-        /// Returns the claims associated with the specified Role.
-        /// </summary>
-        /// <param name="roleId">The ID of the Role whose claims are to be retrieved.</param>
-        /// <returns>A HashSet containing the associated claims.</returns>
-        private async Task<HashSet<string>> GetRoleClaimsAsync(string roleId)
-        {
-            var roleClaimCache = _serviceProvider.GetRequiredService<RoleClaimCache>();
-
-            if (!roleClaimCache.TryGetValue(roleId, out HashSet<string>? hashSet))
-            {
-                var dbContext = (IRepository<TUser, TRole>)
-                    _serviceProvider.GetRequiredService<IHttpContextAccessor>()
-                    .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
-
-                hashSet = (await
-                    dbContext.Set<IdentityRoleClaim<string>>()
-                    .Where(rc => rc.RoleId == roleId && rc.ClaimType == SysClaims.ClaimType)
-                    .Select(rc => rc.ClaimValue!)
-                    .ToArrayAsync()
-                    ).ToHashSet();
-
-                roleClaimCache.Set(
-                    roleId, hashSet,
-                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(3))
-                    );
-            }
-
-            return hashSet!;
-        }
-
-        /// <summary>
-        /// Returns the IDs of the Roles assigned to the specified user.
-        /// </summary>
-        /// <param name="user">The user whose Role IDs are to be returned.</param>
-        /// <returns>A HashSet containing the IDs of the assigned roles.</returns>
-        private async Task<HashSet<string>> GetUserRolesAsync(TUser user)
-        {
-            var dbContext = (IRepository<TUser, TRole>)
-                _serviceProvider.GetRequiredService<IHttpContextAccessor>()
-                    .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
-
-            var roleNames =
-                from uc in user.Claims
-                where uc.UserId == user.Id && uc.ClaimType == ClaimTypes.Role
-                select uc.ClaimValue;
-
-            return (await (
-                from ar in dbContext.Set<TRole>()
-                where roleNames.Contains(ar.Name)
-                select ar.Id
-                ).ToArrayAsync()).ToHashSet();
-        }
-
-        /// <summary>
-        /// Returns the IDs of any Roles assigned to the specified user.
-        /// </summary>
-        /// <param name="userId">The Id of the user whose Role IDs are to be returned.</param>
-        /// <returns>A HashSet containing the IDs of the assigned roles.</returns>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Initialized dbContext instance loaded from IServiceProvider before LINQ query.")]
-        private async Task<HashSet<string>> GetUserRolesAsync(string userId)
-        {
-            var userRoleCache = _serviceProvider.GetRequiredService<UserRoleCache>();
-
-            if (!userRoleCache.TryGetValue(userId, out HashSet<string>? hashSet))
-            {
-                var dbContext = (IRepository<TUser, TRole>)
-                    _serviceProvider.GetRequiredService<IHttpContextAccessor>()
-                    .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
-
-                hashSet = (await (
-                    from uc in dbContext.Set<IdentityUserClaim<string>>()
-                    join ar in dbContext.Set<TRole>() on uc.ClaimValue equals ar.Id
-                    where uc.UserId == userId && uc.ClaimType == ClaimTypes.Role
-                    select ar.Id
-                    ).ToArrayAsync()).ToHashSet();
-
-                userRoleCache.Set(
-                    userId, hashSet,
-                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(3))
-                    );
-            }
-
-            return hashSet!;
-        }
-
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>. 
-        /// </summary>
-        /// <param name="principal">A <see cref="ClaimsPrincipal"/> representing the user.</param>
-        /// <param name="requiredClaims">The claims that the <paramref name="principal"/> must have for authorization to be granted.</param>
-        /// <returns>
-        /// <em>true</em>, if the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>; otherwise, <em>false</em>.
-        /// </returns>
-        public async Task<bool> IsAuthorizedAsync(ClaimsPrincipal principal, params string[] requiredClaims)
-        {
-            var result = await AuthorizeAsync(principal, new AppClaimRequirement(requiredClaims));
-            return result.Succeeded;
-        }
-
-        /// <summary>
-        /// Removes the RoleClaimCache entry of the specified role.
-        /// </summary>
-        /// <param name="roleId">The ID of the Role whose RoleClaimCache entry is to be removed.</param>
-        public void RefreshRole(string roleId)
-        {
-            _serviceProvider.GetRequiredService<RoleClaimCache>()
-                .Remove(roleId);
-        }
-
-        /// <summary>
-        /// Removes the UserRoleCache entry of the specified user.
-        /// </summary>
-        /// <param name="userId">The ID of the User whose UserRoleCache entry is to be removed.</param>
-        public void RefreshUser(string userId)
-        {
-            _serviceProvider.GetRequiredService<UserRoleCache>()
-                .Remove(userId);
-        }
-
-        ///<inheritdoc/>
-        Task<HashSet<string>> IAuthorizationServices.GetRoleClaimsAsync(HashSet<string> roleIds) 
-            => GetRoleClaimsAsync(roleIds);
-
-        ///<inheritdoc/>
-        Task<HashSet<string>> IAuthorizationServices.GetRoleClaimsAsync(string roleId)
-            => GetRoleClaimsAsync(roleId);
-
-        ///<inheritdoc/>
-        Task<HashSet<string>> IAuthorizationServices.GetUserRolesAsync(string userId)
-            => GetUserRolesAsync(userId);
+        LoadSystemClaims(assemblies);
+        LoadSystemGuids(assemblies);
     }
 
     /// <summary>
-    /// Dummy class used for logging.
+    /// Loads the Claims that are installed by the application.
     /// </summary>
-    public class AuthorizationManager
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SysClaims))]
+    [RequiresUnreferencedCode("Types that implement IDefinesClaims might be removed if application is trimmed.")]
+    private static void LoadSystemClaims(List<Assembly> assemblies)
+    {
+        List<IDefinesClaims> claimClasses = [];
+
+        // Load all classes that implement IDefinesClaims interface.
+        foreach (Assembly assembly in assemblies)
+        {
+            claimClasses.AddRange(
+                assembly.GetExportedTypes()
+                    .Where(t => typeof(IDefinesClaims).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+                    .Select(Activator.CreateInstance).Cast<IDefinesClaims>()
+                );
+        }
+
+        // Now retrieve the Claims defined in each class
+        foreach (var claimClass in claimClasses)
+        {
+            DefinedClaims.AddRange(claimClass.DefinedClaims);
+
+            // Save any claims that are marked with the RestrictedClaim attribute
+            RestrictedClaims.AddRange(
+                from FieldInfo fi in claimClass.GetType().GetFields()
+                where Attribute.IsDefined(fi, typeof(RestrictedClaimAttribute))
+                let claim = fi.GetRawConstantValue() as string
+                where claim != null
+                select claim
+                );
+        }
+    }
+
+    /// <summary>
+    /// Loads the GUIDs of the entities installed by the application.
+    /// </summary>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SysGuids))]
+    [RequiresUnreferencedCode("Types that implement IDefinesGuids might be removed if application is trimmed.")]
+    private static void LoadSystemGuids(List<Assembly> assemblies)
+    {
+        List<IDefinesGuids> guidClasses = [];
+
+        // Load all classes that implement IDefinesGuids interface.
+        foreach (Assembly assembly in assemblies)
+        {
+            guidClasses.AddRange(
+                assembly.GetExportedTypes()
+                    .Where(t => typeof(IDefinesGuids).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+                    .Select(Activator.CreateInstance).Cast<IDefinesGuids>()
+                );
+        }
+
+        // Now load the GUIDs defined in each class
+        foreach (var guidClass in guidClasses)
+        {
+            DefinedGuids.AddRange(guidClass.DefinedGuids);
+        }
+    }
+
+
+    /// <summary>
+    /// Contains the Claims that are restricted by the application.
+    /// </summary>
+    private static List<string> RestrictedClaims { get; } = [];
+
+    /// <summary>
+    /// Contains the application Claims installed by the application.
+    /// </summary>
+    private static List<string> DefinedClaims { get; } = [];
+
+    /// <summary>
+    /// Contains the GUIDs of the entities installed by the application.
+    /// </summary>
+    private static List<string> DefinedGuids { get; } = [];
+
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<AuthorizationManager> _logger;
+
+
+    /// <summary>
+    /// Internal constructor for testing framework.
+    /// </summary>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    internal AuthorizationManager()
     { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+    /// <summary>
+    /// Creates a new instance of the AuthorizationManager class using the specified parameters.
+    /// </summary>
+    /// <param name="serviceProvider">The ServiceProvider to be used to access required services.</param>
+    /// <param name="logger">The logger to be used for logging.</param>
+    public AuthorizationManager(IServiceProvider serviceProvider, ILogger<AuthorizationManager> logger)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+
+    /// <summary>
+    /// Returns a list of all claims defined by the application.
+    /// </summary>
+    List<string> IAuthorizationManager.DefinedClaims => DefinedClaims;
+
+    /// <summary>
+    /// Returns a list of all Guids defined by the application.
+    /// </summary>
+    List<string> IAuthorizationManager.DefinedGuids => DefinedGuids;
+
+
+
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/> 
+    /// for the specified <paramref name="resource"/>.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
+    /// <param name="resource">The resource to be tested against.</param>
+    /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
+    /// <returns>
+    /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </returns>
+    public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, object resource, AppClaimRequirement claimRequirement)
+    {
+        if (resource == null)
+        {
+            return await AuthorizeAsync(principal, claimRequirement);
+        }
+
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentNullException.ThrowIfNull(claimRequirement);
+        if (resource is not IRequiresAuthorization raResource)
+            throw new ArgumentException($"Argument does not implement {nameof(IRequiresAuthorization)} interface.", nameof(resource));
+
+        var principalId = principal.UserId();
+        if (principalId == null)
+        {
+            _logger.LogDebug(
+                "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
+                nameof(AppClaimRequirement), claimRequirement, principal.UserName()
+                );
+            return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
+        }
+
+        // Is this a system User or Role?
+        if (DefinedGuids.Contains(raResource.Id))
+        {
+            // Yes - fail requests for restricted claims
+            var failedClaims = claimRequirement.ClaimValues.Intersect(RestrictedClaims);
+            if (failedClaims.Any())
+            {
+                var userName = principal.UserName();
+                var resourceType = resource.GetType().Name;
+                var failedClaim = failedClaims.First();
+
+                _logger.LogInformation(
+                    "{ClassName} of \"{Claim}\" for {ResourceType} '{ObjectName}' not met by '{UserName}' - restricted operation on system User or Role.",
+                    nameof(AppClaimRequirement), failedClaim, resourceType, raResource.Name, userName
+                    );
+                return AuthorizationResult.SystemObject(failedClaims);
+            }
+        }
+
+        var result = await AuthorizeInternalAsync(principal, claimRequirement);
+        if (!result.Succeeded)
+        {
+            return result;
+        }
+
+        // See if there is a IResourceHandler implementation for the resource 
+        var handler = _serviceProvider.GetRequiredService(
+            typeof(IResourceAuthorizationHandler<>).MakeGenericType(resource.GetType())
+            ) as IResourceAuthorizationHandler;
+
+        if (handler is not null)
+        {
+            return await handler.HandleAsync(
+                new ResourceAuthorizationHandlerContext(this, raResource, principal, claimRequirement)
+                );
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
+    /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
+    /// <returns>
+    /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </returns>
+    public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+        ArgumentNullException.ThrowIfNull(claimRequirement);
+
+        var userId = principal.UserId();
+        if (userId == null)
+        {
+            _logger.LogDebug(
+                "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.",
+                nameof(AppClaimRequirement), claimRequirement, principal.UserName()
+                );
+            return AuthorizationResult.NoUserId(claimRequirement.ClaimValues);
+        }
+
+        return await AuthorizeInternalAsync(principal, claimRequirement);
+    }
+
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
+    /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
+    /// <returns>
+    /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </returns>
+    private async Task<AuthorizationResult> AuthorizeInternalAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement)
+    {
+        var userId = principal.UserId() ?? throw new InvalidOperationException("Specified ClaimsPrincipal does not have a 'NameIdentifier' Claim.");
+
+        var principalRoles = await GetUserRolesAsync(userId);
+        if (principalRoles.Contains(SysGuids.Role.Administrator))
+        {
+            _logger.LogDebug(
+                "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}' via {RoleName} role.",
+                nameof(AppClaimRequirement), claimRequirement, principal.UserName(), nameof(SysGuids.Role.Administrator)
+                );
+            return AuthorizationResult.Success();
+        }
+
+        HashSet<string> principalClaims = await GetRoleClaimsAsync(principalRoles);
+        if (claimRequirement.ClaimValues.IsSubsetOf(principalClaims))
+        {
+            _logger.LogDebug(
+                "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}'.",
+                nameof(AppClaimRequirement), claimRequirement, principal.UserName()
+                );
+            return AuthorizationResult.Success();
+        }
+
+        return AuthorizationResult.Failed(
+            claimRequirement.ClaimValues.Except(principalClaims)
+            );
+    }
+
+    /// <summary>
+    /// Returns the claims associated with the specified Roles.
+    /// </summary>
+    /// <param name="roleIds">A HashSet containing the IDs of the Roles whose claims are to be retrieved.</param>
+    /// <returns>A HashSet containing the associated claims.</returns>
+    private async Task<HashSet<string>> GetRoleClaimsAsync(HashSet<string> roleIds)
+    {
+        var claimHash = new HashSet<string>();
+
+        foreach (var roleId in roleIds)
+        {
+            claimHash.UnionWith(await GetRoleClaimsAsync(roleId));
+        }
+
+        return claimHash;
+    }
+
+    /// <summary>
+    /// Returns the claims associated with the specified Role.
+    /// </summary>
+    /// <param name="roleId">The ID of the Role whose claims are to be retrieved.</param>
+    /// <returns>A HashSet containing the associated claims.</returns>
+    private async Task<HashSet<string>> GetRoleClaimsAsync(string roleId)
+    {
+        var roleClaimCache = _serviceProvider.GetRequiredService<RoleClaimCache>();
+
+        if (!roleClaimCache.TryGetValue(roleId, out HashSet<string>? hashSet))
+        {
+            var dbContext = (IRepository<TUser, TRole>)
+                _serviceProvider.GetRequiredService<IHttpContextAccessor>()
+                .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
+
+            hashSet = (await
+                dbContext.Set<IdentityRoleClaim<string>>()
+                .Where(rc => rc.RoleId == roleId && rc.ClaimType == SysClaims.ClaimType)
+                .Select(rc => rc.ClaimValue!)
+                .ToArrayAsync()
+                ).ToHashSet();
+
+            roleClaimCache.Set(
+                roleId, hashSet,
+                new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(3))
+                );
+        }
+
+        return hashSet!;
+    }
+
+    /// <summary>
+    /// Returns the IDs of the Roles assigned to the specified user.
+    /// </summary>
+    /// <param name="user">The user whose Role IDs are to be returned.</param>
+    /// <returns>A HashSet containing the IDs of the assigned roles.</returns>
+    private async Task<HashSet<string>> GetUserRolesAsync(TUser user)
+    {
+        var dbContext = (IRepository<TUser, TRole>)
+            _serviceProvider.GetRequiredService<IHttpContextAccessor>()
+                .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
+
+        var roleNames =
+            from uc in user.Claims
+            where uc.UserId == user.Id && uc.ClaimType == ClaimTypes.Role
+            select uc.ClaimValue;
+
+        return (await (
+            from ar in dbContext.Set<TRole>()
+            where roleNames.Contains(ar.Name)
+            select ar.Id
+            ).ToArrayAsync()).ToHashSet();
+    }
+
+    /// <summary>
+    /// Returns the IDs of any Roles assigned to the specified user.
+    /// </summary>
+    /// <param name="userId">The Id of the user whose Role IDs are to be returned.</param>
+    /// <returns>A HashSet containing the IDs of the assigned roles.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Initialized dbContext instance loaded from IServiceProvider before LINQ query.")]
+    private async Task<HashSet<string>> GetUserRolesAsync(string userId)
+    {
+        var userRoleCache = _serviceProvider.GetRequiredService<UserRoleCache>();
+
+        if (!userRoleCache.TryGetValue(userId, out HashSet<string>? hashSet))
+        {
+            var dbContext = (IRepository<TUser, TRole>)
+                _serviceProvider.GetRequiredService<IHttpContextAccessor>()
+                .HttpContext!.RequestServices.GetRequiredService(typeof(IRepository<TUser, TRole>));
+
+            hashSet = (await (
+                from uc in dbContext.Set<IdentityUserClaim<string>>()
+                join ar in dbContext.Set<TRole>() on uc.ClaimValue equals ar.Id
+                where uc.UserId == userId && uc.ClaimType == ClaimTypes.Role
+                select ar.Id
+                ).ToArrayAsync()).ToHashSet();
+
+            userRoleCache.Set(
+                userId, hashSet,
+                new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(3))
+                );
+        }
+
+        return hashSet!;
+    }
+
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>. 
+    /// </summary>
+    /// <param name="principal">A <see cref="ClaimsPrincipal"/> representing the user.</param>
+    /// <param name="requiredClaims">The claims that the <paramref name="principal"/> must have for authorization to be granted.</param>
+    /// <returns>
+    /// <em>true</em>, if the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>; otherwise, <em>false</em>.
+    /// </returns>
+    public async Task<bool> IsAuthorizedAsync(ClaimsPrincipal principal, params string[] requiredClaims)
+    {
+        var result = await AuthorizeAsync(principal, new AppClaimRequirement(requiredClaims));
+        return result.Succeeded;
+    }
+
+    /// <summary>
+    /// Removes the RoleClaimCache entry of the specified role.
+    /// </summary>
+    /// <param name="roleId">The ID of the Role whose RoleClaimCache entry is to be removed.</param>
+    public void RefreshRole(string roleId)
+    {
+        _serviceProvider.GetRequiredService<RoleClaimCache>()
+            .Remove(roleId);
+    }
+
+    /// <summary>
+    /// Removes the UserRoleCache entry of the specified user.
+    /// </summary>
+    /// <param name="userId">The ID of the User whose UserRoleCache entry is to be removed.</param>
+    public void RefreshUser(string userId)
+    {
+        _serviceProvider.GetRequiredService<UserRoleCache>()
+            .Remove(userId);
+    }
+
+    ///<inheritdoc/>
+    Task<HashSet<string>> IAuthorizationServices.GetRoleClaimsAsync(HashSet<string> roleIds) 
+        => GetRoleClaimsAsync(roleIds);
+
+    ///<inheritdoc/>
+    Task<HashSet<string>> IAuthorizationServices.GetRoleClaimsAsync(string roleId)
+        => GetRoleClaimsAsync(roleId);
+
+    ///<inheritdoc/>
+    Task<HashSet<string>> IAuthorizationServices.GetUserRolesAsync(string userId)
+        => GetUserRolesAsync(userId);
 }
+
+/// <summary>
+/// Dummy class used for logging.
+/// </summary>
+public class AuthorizationManager
+{ }

--- a/Authorization.Core/AuthorizationResult.cs
+++ b/Authorization.Core/AuthorizationResult.cs
@@ -1,76 +1,73 @@
-﻿using System.Collections.Generic;
+﻿namespace CRFricke.Authorization.Core;
 
-namespace CRFricke.Authorization.Core
+/// <summary>
+/// Represents the result of an authorization request.
+/// </summary>
+public class AuthorizationResult
 {
     /// <summary>
-    /// Represents the result of an authorization request.
+    /// Creates a new instance of the AuthorizationResult class with default values.
     /// </summary>
-    public class AuthorizationResult
+    public AuthorizationResult()
+    { }
+
+    /// <summary>
+    /// Flag indicating whether the request succeeded or not.
+    /// </summary>
+    public bool Succeeded { get; private set; }
+
+    /// <summary>
+    /// Returns an <see cref="AuthorizationFailure"/> object that describes why the user is not authorized.
+    /// </summary>
+    public AuthorizationFailure? Failure { get; private set; }
+
+    /// <summary>
+    /// Returns a string representing the current <see cref="AuthorizationResult"/> object.
+    /// </summary>
+    /// <returns>A string representing the current <see cref="AuthorizationResult"/> object.</returns>
+    public override string ToString()
     {
-        /// <summary>
-        /// Creates a new instance of the AuthorizationResult class with default values.
-        /// </summary>
-        public AuthorizationResult()
-        { }
-
-        /// <summary>
-        /// Flag indicating whether the request succeeded or not.
-        /// </summary>
-        public bool Succeeded { get; private set; }
-
-        /// <summary>
-        /// Returns an <see cref="AuthorizationFailure"/> object that describes why the user is not authorized.
-        /// </summary>
-        public AuthorizationFailure? Failure { get; private set; }
-
-        /// <summary>
-        /// Returns a string representing the current <see cref="AuthorizationResult"/> object.
-        /// </summary>
-        /// <returns>A string representing the current <see cref="AuthorizationResult"/> object.</returns>
-        public override string ToString()
-        {
-            return Succeeded
-                ? nameof(Succeeded)
-                : Failure?.FailureReason ?? nameof(Failed);
-        }
-
-
-        /// <summary>
-        /// Returns an AuthorizationResult object indicating success.
-        /// </summary>
-        /// <returns></returns>
-        public static AuthorizationResult Success() => new() { Succeeded = true };
-
-        /// <summary>
-        /// Creates an AuthorizationResult object indicating an authorization failure, with a list of failing claims if applicable.
-        /// </summary>
-        /// <param name="failingClaims">An optional collection of the required claims which were not met.</param>
-        /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
-        public static AuthorizationResult Failed(IEnumerable<string>? failingClaims = null)
-            => new() { Failure = AuthorizationFailure.NotAuthorized(failingClaims) };
-
-        /// <summary>
-        /// Creates an AuthorizationResult object indicating an attempt to elevate privileges, with a list of the offending claims.
-        /// </summary>
-        /// <param name="failingClaims">A collection of the requested claims that would elevate privileges.</param>
-        /// <returns>An AuthorizationResult object describing the elevation error.</returns>
-        public static AuthorizationResult Elevation(IEnumerable<string>? failingClaims = null)
-            => new() { Failure = AuthorizationFailure.Elevation(failingClaims) };
-
-        /// <summary>
-        /// Creates an AuthorizationResult object indicating a failure to determine the current user, with a list of the required claims.
-        /// </summary>
-        /// <param name="failingClaims">A collection of the required claims.</param>
-        /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
-        public static AuthorizationResult NoUserId(IEnumerable<string>? failingClaims = null)
-            => new() { Failure = AuthorizationFailure.NoUserId(failingClaims) };
-
-        /// <summary>
-        /// Creates an AuthorizationResult object indicating an invalid attempt to update a system object, with a list of the offending claims.
-        /// </summary>
-        /// <param name="failingClaims">A collection of the requested claims that are privileged.</param>
-        /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
-        public static AuthorizationResult SystemObject(IEnumerable<string>? failingClaims = null)
-            => new() { Failure = AuthorizationFailure.SystemObject(failingClaims) };
+        return Succeeded
+            ? nameof(Succeeded)
+            : Failure?.FailureReason ?? nameof(Failed);
     }
+
+
+    /// <summary>
+    /// Returns an AuthorizationResult object indicating success.
+    /// </summary>
+    /// <returns></returns>
+    public static AuthorizationResult Success() => new() { Succeeded = true };
+
+    /// <summary>
+    /// Creates an AuthorizationResult object indicating an authorization failure, with a list of failing claims if applicable.
+    /// </summary>
+    /// <param name="failingClaims">An optional collection of the required claims which were not met.</param>
+    /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
+    public static AuthorizationResult Failed(IEnumerable<string>? failingClaims = null)
+        => new() { Failure = AuthorizationFailure.NotAuthorized(failingClaims) };
+
+    /// <summary>
+    /// Creates an AuthorizationResult object indicating an attempt to elevate privileges, with a list of the offending claims.
+    /// </summary>
+    /// <param name="failingClaims">A collection of the requested claims that would elevate privileges.</param>
+    /// <returns>An AuthorizationResult object describing the elevation error.</returns>
+    public static AuthorizationResult Elevation(IEnumerable<string>? failingClaims = null)
+        => new() { Failure = AuthorizationFailure.Elevation(failingClaims) };
+
+    /// <summary>
+    /// Creates an AuthorizationResult object indicating a failure to determine the current user, with a list of the required claims.
+    /// </summary>
+    /// <param name="failingClaims">A collection of the required claims.</param>
+    /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
+    public static AuthorizationResult NoUserId(IEnumerable<string>? failingClaims = null)
+        => new() { Failure = AuthorizationFailure.NoUserId(failingClaims) };
+
+    /// <summary>
+    /// Creates an AuthorizationResult object indicating an invalid attempt to update a system object, with a list of the offending claims.
+    /// </summary>
+    /// <param name="failingClaims">A collection of the requested claims that are privileged.</param>
+    /// <returns>An AuthorizationResult object describing the reason for the failure.</returns>
+    public static AuthorizationResult SystemObject(IEnumerable<string>? failingClaims = null)
+        => new() { Failure = AuthorizationFailure.SystemObject(failingClaims) };
 }

--- a/Authorization.Core/ClaimsPrincipalExtensions.cs
+++ b/Authorization.Core/ClaimsPrincipalExtensions.cs
@@ -1,27 +1,25 @@
-﻿using System.Linq;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Provides extension methods for the <see cref="ClaimsPrincipal"/> class.
+/// </summary>
+public static class ClaimsPrincipalExtensions
 {
     /// <summary>
-    /// Provides extension methods for the <see cref="ClaimsPrincipal"/> class.
+    /// Returns the user ID associated with the ClaimsPrincipal (<em>null</em>, if the ID cannot be located on the ClaimsPrincipal).
     /// </summary>
-    public static class ClaimsPrincipalExtensions
-    {
-        /// <summary>
-        /// Returns the user ID associated with the ClaimsPrincipal (<em>null</em>, if the ID cannot be located on the ClaimsPrincipal).
-        /// </summary>
-        /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
-        /// <returns>The user ID associated with the ClaimsPrincipal.</returns>
-        public static string? UserId(this ClaimsPrincipal claimsPrincipal)
-            => claimsPrincipal.Claims.Where(c => c.Type == ClaimTypes.NameIdentifier).FirstOrDefault()?.Value;
+    /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
+    /// <returns>The user ID associated with the ClaimsPrincipal.</returns>
+    public static string? UserId(this ClaimsPrincipal claimsPrincipal)
+        => claimsPrincipal.Claims.Where(c => c.Type == ClaimTypes.NameIdentifier).FirstOrDefault()?.Value;
 
-        /// <summary>
-        /// Returns the user name associated with the ClaimsPrincipal ("&lt;unknown&gt;", if the ID cannot be located on the ClaimsPrincipal).
-        /// </summary>
-        /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
-        /// <returns>The user name associated with the ClaimsPrincipal.</returns>
-        public static string UserName(this ClaimsPrincipal claimsPrincipal)
-            => claimsPrincipal.Identity?.Name ?? "<unknown>";
-    }
+    /// <summary>
+    /// Returns the user name associated with the ClaimsPrincipal ("&lt;unknown&gt;", if the ID cannot be located on the ClaimsPrincipal).
+    /// </summary>
+    /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
+    /// <returns>The user name associated with the ClaimsPrincipal.</returns>
+    public static string UserName(this ClaimsPrincipal claimsPrincipal)
+        => claimsPrincipal.Identity?.Name ?? "<unknown>";
 }

--- a/Authorization.Core/ClaimsPrincipalExtensions.cs
+++ b/Authorization.Core/ClaimsPrincipalExtensions.cs
@@ -7,19 +7,20 @@ namespace CRFricke.Authorization.Core;
 /// </summary>
 public static class ClaimsPrincipalExtensions
 {
-    /// <summary>
-    /// Returns the user ID associated with the ClaimsPrincipal (<em>null</em>, if the ID cannot be located on the ClaimsPrincipal).
-    /// </summary>
-    /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
-    /// <returns>The user ID associated with the ClaimsPrincipal.</returns>
-    public static string? UserId(this ClaimsPrincipal claimsPrincipal)
-        => claimsPrincipal.Claims.Where(c => c.Type == ClaimTypes.NameIdentifier).FirstOrDefault()?.Value;
+    extension(ClaimsPrincipal claimsPrincipal)
+    {
+        /// <summary>
+        /// Returns the user ID associated with the ClaimsPrincipal (<em>null</em>, if the ID cannot be located on the ClaimsPrincipal).
+        /// </summary>
+        /// <returns>The user ID associated with the ClaimsPrincipal.</returns>
+        public string? UserId()
+            => claimsPrincipal.Claims.Where(c => c.Type == ClaimTypes.NameIdentifier).FirstOrDefault()?.Value;
 
-    /// <summary>
-    /// Returns the user name associated with the ClaimsPrincipal ("&lt;unknown&gt;", if the ID cannot be located on the ClaimsPrincipal).
-    /// </summary>
-    /// <param name="claimsPrincipal">The ClaimsPrincipal of the user.</param>
-    /// <returns>The user name associated with the ClaimsPrincipal.</returns>
-    public static string UserName(this ClaimsPrincipal claimsPrincipal)
-        => claimsPrincipal.Identity?.Name ?? "<unknown>";
+        /// <summary>
+        /// Returns the user name associated with the ClaimsPrincipal ("&lt;unknown&gt;", if the ID cannot be located on the ClaimsPrincipal).
+        /// </summary>
+        /// <returns>The user name associated with the ClaimsPrincipal.</returns>
+        public string UserName()
+            => claimsPrincipal.Identity?.Name ?? "<unknown>";
+    }
 }

--- a/Authorization.Core/Data/AuthDbContext.cs
+++ b/Authorization.Core/Data/AuthDbContext.cs
@@ -4,206 +4,202 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Linq;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core.Data
+namespace CRFricke.Authorization.Core.Data;
+
+/// <summary>
+/// Base class for a database context used by the Authorization.Core library.
+/// </summary>
+public class AuthDbContext : AuthDbContext<AuthUser, AuthRole>
 {
     /// <summary>
-    /// Base class for a database context used by the Authorization.Core library.
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using default options.
     /// </summary>
-    public class AuthDbContext : AuthDbContext<AuthUser, AuthRole>
+    protected AuthDbContext()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
+    public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
+    protected AuthDbContext(DbContextOptions options) : base(options)
+    { }
+}
+
+/// <summary>
+/// Base class for a database context used by the Authorization.Core library.
+/// </summary>
+/// <typeparam name="TUser">The <see cref="Type"/> of user objects.</typeparam>
+/// <typeparam name="TRole">The <see cref="Type"/> of role objects.</typeparam>
+public abstract class AuthDbContext<
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole > 
+    : IdentityDbContext<TUser, TRole, string>, IRepository<TUser, TRole>, ISeedingContext
+    where TUser : AuthUser, new()
+    where TRole : AuthRole, new()
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using default options.
+    /// </summary>
+    protected AuthDbContext()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
+    public AuthDbContext(DbContextOptions<AuthDbContext<TUser, TRole>> options) : base(options)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
+    /// </summary>
+    /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
+    protected AuthDbContext(DbContextOptions options) : base(options)
+    { }
+
+    /// <summary>
+    /// Configures the schema needed for the Authorization.Core library.
+    /// </summary>
+    /// <param name="builder">
+    /// The builder being used to construct the model for this context.
+    /// </param>
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using default options.
-        /// </summary>
-        protected AuthDbContext()
-        { }
+        base.OnModelCreating(builder);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
-        /// </summary>
-        /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
-        public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options)
-        { }
+        builder.Entity<TRole>()
+            .HasMany(e => e.Claims)
+            .WithOne()
+            .HasForeignKey(e => e.RoleId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
-        /// </summary>
-        /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
-        protected AuthDbContext(DbContextOptions options) : base(options)
-        { }
+        builder.Entity<TUser>()
+            .HasMany(e => e.Claims)
+            .WithOne()
+            .HasForeignKey(e => e.UserId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
+    {
+        var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<AuthDbContext>();
+
+        await FixupUserClaimValuesAsync(logger);
+
+        var hasher = serviceProvider.GetRequiredService<IPasswordHasher<TUser>>();
+        var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
+
+        var role = await Roles.FindAsync(SysGuids.Role.Administrator);
+        if (role == null)
+        {
+            role = new TRole
+            {
+                Id = SysGuids.Role.Administrator,
+                Name = nameof(SysGuids.Role.Administrator),
+                NormalizedName = normalizer.NormalizeName(nameof(SysGuids.Role.Administrator))
+            };
+
+            await Roles.AddAsync(role);
+            logger.LogInformation(
+                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
+                typeof(TRole).Name, role.Name, role.Id
+                );
+        }
+
+        var user = await Users.FindAsync(SysGuids.User.Administrator);
+        if (user == null)
+        {
+            var email = "Admin@company.com";
+
+            user = new TUser
+            {
+                Id = SysGuids.User.Administrator,
+                Email = email,
+                EmailConfirmed = true,
+                LockoutEnabled = true,
+                NormalizedEmail = normalizer.NormalizeEmail(email),
+                NormalizedUserName = normalizer.NormalizeName(email),
+                PasswordHash = hasher.HashPassword(user!, "Administrat0r!"),
+                UserName = email
+            };
+            ((AuthUser)user).SetClaims(role.Id);
+
+            await Users.AddAsync(user);
+            logger.LogInformation(
+                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
+                typeof(TUser).Name, user.Email, user.Id
+                );
+        }
+
+        try
+        {
+            await SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "SaveChangesAsync() method failed.");
+        }
     }
 
     /// <summary>
-    /// Base class for a database context used by the Authorization.Core library.
+    /// Called to fix up UserClaim values after the change to reference Role ID rather than Name.
     /// </summary>
-    /// <typeparam name="TUser">The <see cref="Type"/> of user objects.</typeparam>
-    /// <typeparam name="TRole">The <see cref="Type"/> of role objects.</typeparam>
-    public abstract class AuthDbContext<
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole > 
-        : IdentityDbContext<TUser, TRole, string>, IRepository<TUser, TRole>, ISeedingContext
-        where TUser : AuthUser, new()
-        where TRole : AuthRole, new()
+    /// <param name="logger">A logger for logging results.</param>
+    /// <returns>A task that can be awaited on.</returns>
+    /// <remarks>
+    /// Prior to version 8.0.1, we stored the name of the Role in UserClaim.ClaimValue.
+    /// If the name of the Role was updated afterwards, the UserClaim was orphaned.
+    /// We now store the ID of the Role to prevent this.
+    /// </remarks>
+    private async Task FixupUserClaimValuesAsync(ILogger<AuthDbContext> logger)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using default options.
-        /// </summary>
-        protected AuthDbContext()
-        { }
+        var userClaims = 
+            from uc in UserClaims
+            join ar in Roles on uc.ClaimValue equals ar.Name
+            where uc.ClaimType == ClaimTypes.Role
+            select uc;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
-        /// </summary>
-        /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
-        public AuthDbContext(DbContextOptions<AuthDbContext<TUser, TRole>> options) : base(options)
-        { }
+        var userClaimCount = await userClaims.CountAsync();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
-        /// </summary>
-        /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
-        protected AuthDbContext(DbContextOptions options) : base(options)
-        { }
-
-        /// <summary>
-        /// Configures the schema needed for the Authorization.Core library.
-        /// </summary>
-        /// <param name="builder">
-        /// The builder being used to construct the model for this context.
-        /// </param>
-        protected override void OnModelCreating(ModelBuilder builder)
+        if (userClaimCount == 0)
         {
-            base.OnModelCreating(builder);
-
-            builder.Entity<TRole>()
-                .HasMany(e => e.Claims)
-                .WithOne()
-                .HasForeignKey(e => e.RoleId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Cascade);
-
-            builder.Entity<TUser>()
-                .HasMany(e => e.Claims)
-                .WithOne()
-                .HasForeignKey(e => e.UserId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Cascade);
+            return;
         }
 
-        /// <inheritdoc/>
-        public virtual async Task SeedDatabaseAsync(IServiceProvider serviceProvider)
+        var roleDictionary = await Roles
+            .Where(r => r.Name != null)
+            .ToDictionaryAsync(k => k.Name!, e => e.Id);
+
+        foreach (var claim in userClaims)
         {
-            var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<AuthDbContext>();
-
-            await FixupUserClaimValuesAsync(logger);
-
-            var hasher = serviceProvider.GetRequiredService<IPasswordHasher<TUser>>();
-            var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
-
-            var role = await Roles.FindAsync(SysGuids.Role.Administrator);
-            if (role == null)
-            {
-                role = new TRole
-                {
-                    Id = SysGuids.Role.Administrator,
-                    Name = nameof(SysGuids.Role.Administrator),
-                    NormalizedName = normalizer.NormalizeName(nameof(SysGuids.Role.Administrator))
-                };
-
-                await Roles.AddAsync(role);
-                logger.LogInformation(
-                    "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
-                    typeof(TRole).Name, role.Name, role.Id
-                    );
-            }
-
-            var user = await Users.FindAsync(SysGuids.User.Administrator);
-            if (user == null)
-            {
-                var email = "Admin@company.com";
-
-                user = new TUser
-                {
-                    Id = SysGuids.User.Administrator,
-                    Email = email,
-                    EmailConfirmed = true,
-                    LockoutEnabled = true,
-                    NormalizedEmail = normalizer.NormalizeEmail(email),
-                    NormalizedUserName = normalizer.NormalizeName(email),
-                    PasswordHash = hasher.HashPassword(user!, "Administrat0r!"),
-                    UserName = email
-                };
-                ((AuthUser)user).SetClaims(role.Id);
-
-                await Users.AddAsync(user);
-                logger.LogInformation(
-                    "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
-                    typeof(TUser).Name, user.Email, user.Id
-                    );
-            }
-
-            try
-            {
-                await SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "SaveChangesAsync() method failed.");
-            }
+            claim.ClaimValue = roleDictionary[claim.ClaimValue!];
         }
 
-        /// <summary>
-        /// Called to fix up UserClaim values after the change to reference Role ID rather than Name.
-        /// </summary>
-        /// <param name="logger">A logger for logging results.</param>
-        /// <returns>A task that can be awaited on.</returns>
-        /// <remarks>
-        /// Prior to version 8.0.1, we stored the name of the Role in UserClaim.ClaimValue.
-        /// If the name of the Role was updated afterwards, the UserClaim was orphaned.
-        /// We now store the ID of the Role to prevent this.
-        /// </remarks>
-        private async Task FixupUserClaimValuesAsync(ILogger<AuthDbContext> logger)
+        try
         {
-            var userClaims = 
-                from uc in UserClaims
-                join ar in Roles on uc.ClaimValue equals ar.Name
-                where uc.ClaimType == ClaimTypes.Role
-                select uc;
+            await SaveChangesAsync();
 
-            var userClaimCount = await userClaims.CountAsync();
-
-            if (userClaimCount == 0)
-            {
-                return;
-            }
-
-            var roleDictionary = await Roles
-                .Where(r => r.Name != null)
-                .ToDictionaryAsync(k => k.Name!, e => e.Id);
-
-            foreach (var claim in userClaims)
-            {
-                claim.ClaimValue = roleDictionary[claim.ClaimValue!];
-            }
-
-            try
-            {
-                await SaveChangesAsync();
-
-                logger.LogInformation(
-                    "Fixup successful for {UpdateCount} {UpdateEntity}.", 
-                    userClaimCount, nameof(UserClaims)
-                    );
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "FixupUserClaimValuesAsync() method failed.");
-            }
+            logger.LogInformation(
+                "Fixup successful for {UpdateCount} {UpdateEntity}.", 
+                userClaimCount, nameof(UserClaims)
+                );
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "FixupUserClaimValuesAsync() method failed.");
         }
     }
 }

--- a/Authorization.Core/Data/AuthDbContext.cs
+++ b/Authorization.Core/Data/AuthDbContext.cs
@@ -57,7 +57,7 @@ public abstract class AuthDbContext<
     /// Initializes a new instance of the <see cref="AuthDbContext"/> class using the specified options.
     /// </summary>
     /// <param name="options">The options to be used by the new <see cref="AuthDbContext"/> instance.</param>
-    public AuthDbContext(DbContextOptions<AuthDbContext<TUser, TRole>> options) : base(options)
+    protected AuthDbContext(DbContextOptions<AuthDbContext<TUser, TRole>> options) : base(options)
     { }
 
     /// <summary>
@@ -75,6 +75,8 @@ public abstract class AuthDbContext<
     /// </param>
     protected override void OnModelCreating(ModelBuilder builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         base.OnModelCreating(builder);
 
         builder.Entity<TRole>()
@@ -97,12 +99,12 @@ public abstract class AuthDbContext<
     {
         var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<AuthDbContext>();
 
-        await FixupUserClaimValuesAsync(logger);
+        await FixupUserClaimValuesAsync(logger).ConfigureAwait(false);
 
         var hasher = serviceProvider.GetRequiredService<IPasswordHasher<TUser>>();
         var normalizer = serviceProvider.GetRequiredService<ILookupNormalizer>();
 
-        var role = await Roles.FindAsync(SysGuids.Role.Administrator);
+        var role = await Roles.FindAsync(SysGuids.Role.Administrator).ConfigureAwait(false);
         if (role == null)
         {
             role = new TRole
@@ -112,14 +114,14 @@ public abstract class AuthDbContext<
                 NormalizedName = normalizer.NormalizeName(nameof(SysGuids.Role.Administrator))
             };
 
-            await Roles.AddAsync(role);
+            await Roles.AddAsync(role).ConfigureAwait(false);
             logger.LogInformation(
                 "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
                 typeof(TRole).Name, role.Name, role.Id
                 );
         }
 
-        var user = await Users.FindAsync(SysGuids.User.Administrator);
+        var user = await Users.FindAsync(SysGuids.User.Administrator).ConfigureAwait(false);
         if (user == null)
         {
             var email = "Admin@company.com";
@@ -135,23 +137,25 @@ public abstract class AuthDbContext<
                 PasswordHash = hasher.HashPassword(user!, "Administrat0r!"),
                 UserName = email
             };
-            ((AuthUser)user).SetClaims(role.Id);
+            user.SetClaims<TUser>(role.Id);
 
-            await Users.AddAsync(user);
+            await Users.AddAsync(user).ConfigureAwait(false);
             logger.LogInformation(
                 "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
                 typeof(TUser).Name, user.Email, user.Id
                 );
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            await SaveChangesAsync();
+            await SaveChangesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "SaveChangesAsync() method failed.");
         }
+#pragma warning restore CA1031 // Do not catch general exception types
     }
 
     /// <summary>
@@ -172,7 +176,7 @@ public abstract class AuthDbContext<
             where uc.ClaimType == ClaimTypes.Role
             select uc;
 
-        var userClaimCount = await userClaims.CountAsync();
+        var userClaimCount = await userClaims.CountAsync().ConfigureAwait(false);
 
         if (userClaimCount == 0)
         {
@@ -181,16 +185,17 @@ public abstract class AuthDbContext<
 
         var roleDictionary = await Roles
             .Where(r => r.Name != null)
-            .ToDictionaryAsync(k => k.Name!, e => e.Id);
+            .ToDictionaryAsync(k => k.Name!, e => e.Id).ConfigureAwait(false);
 
         foreach (var claim in userClaims)
         {
             claim.ClaimValue = roleDictionary[claim.ClaimValue!];
         }
 
+#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            await SaveChangesAsync();
+            await SaveChangesAsync().ConfigureAwait(false);
 
             logger.LogInformation(
                 "Fixup successful for {UpdateCount} {UpdateEntity}.", 
@@ -201,5 +206,6 @@ public abstract class AuthDbContext<
         {
             logger.LogError(ex, "FixupUserClaimValuesAsync() method failed.");
         }
+#pragma warning restore CA1031 // Do not catch general exception types
     }
 }

--- a/Authorization.Core/Data/AuthDbContext.cs
+++ b/Authorization.Core/Data/AuthDbContext.cs
@@ -115,8 +115,7 @@ public abstract class AuthDbContext<
             };
 
             await Roles.AddAsync(role).ConfigureAwait(false);
-            logger.LogInformation(
-                "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.",
+            logger.LogRoleCreated(
                 typeof(TRole).Name, role.Name, role.Id
                 );
         }
@@ -140,8 +139,7 @@ public abstract class AuthDbContext<
             user.SetClaims<TUser>(role.Id);
 
             await Users.AddAsync(user).ConfigureAwait(false);
-            logger.LogInformation(
-                "{UserType} '{UserEmail}' (ID: {UserId}) has been created.",
+            logger.LogUserCreated(
                 typeof(TUser).Name, user.Email, user.Id
                 );
         }
@@ -153,7 +151,7 @@ public abstract class AuthDbContext<
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "SaveChangesAsync() method failed.");
+            logger.LogSaveChangesFailed(ex);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }
@@ -197,14 +195,13 @@ public abstract class AuthDbContext<
         {
             await SaveChangesAsync().ConfigureAwait(false);
 
-            logger.LogInformation(
-                "Fixup successful for {UpdateCount} {UpdateEntity}.", 
+            logger.LogFixupSuccessful(
                 userClaimCount, nameof(UserClaims)
                 );
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "FixupUserClaimValuesAsync() method failed.");
+            logger.LogFixupUserClaimValuesFailed(ex);
         }
 #pragma warning restore CA1031 // Do not catch general exception types
     }

--- a/Authorization.Core/Data/AuthRole.cs
+++ b/Authorization.Core/Data/AuthRole.cs
@@ -1,16 +1,14 @@
 ﻿using Microsoft.AspNetCore.Identity;
-using System.Collections.Generic;
 
-namespace CRFricke.Authorization.Core.Data
+namespace CRFricke.Authorization.Core.Data;
+
+/// <summary>
+/// Base class for application roles.
+/// </summary>
+public class AuthRole : IdentityRole, IRequiresAuthorization
 {
     /// <summary>
-    /// Base class for application roles.
+    /// The claims that have been granted to this application role.
     /// </summary>
-    public class AuthRole : IdentityRole, IRequiresAuthorization
-    {
-        /// <summary>
-        /// The claims that have been granted to this application role.
-        /// </summary>
-        public virtual ICollection<IdentityRoleClaim<string>> Claims { get; } = new List<IdentityRoleClaim<string>>();
-    }
+    public virtual ICollection<IdentityRoleClaim<string>> Claims { get; } = [];
 }

--- a/Authorization.Core/Data/AuthUser.cs
+++ b/Authorization.Core/Data/AuthUser.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity;
 
+#pragma warning disable CA1033 // Interface methods should be callable by child types
+
 namespace CRFricke.Authorization.Core.Data;
 
 /// <summary>

--- a/Authorization.Core/Data/AuthUser.cs
+++ b/Authorization.Core/Data/AuthUser.cs
@@ -1,42 +1,40 @@
 ﻿using Microsoft.AspNetCore.Identity;
-using System.Collections.Generic;
 
-namespace CRFricke.Authorization.Core.Data
+namespace CRFricke.Authorization.Core.Data;
+
+/// <summary>
+/// Base class for application users.
+/// </summary>
+public class AuthUser : IdentityUser, IRequiresAuthorization
 {
     /// <summary>
-    /// Base class for application users.
+    /// Creates a new instance of the <see cref="AuthUser"/> class.
     /// </summary>
-    public class AuthUser : IdentityUser, IRequiresAuthorization
+    public AuthUser()
+    { }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="AuthUser"/> class with the specified email address.
+    /// </summary>
+    /// <param name="email">The email address of the new <see cref="AuthUser"/>.</param>
+    public AuthUser(string email) : this(email, email)
+    { }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="AuthUser"/> class with the specified email address and user name.
+    /// </summary>
+    /// <param name="email">The email address of the new <see cref="AuthUser"/>.</param>
+    /// <param name="userName">The user name of the new <see cref="AuthUser"/>.</param>
+    public AuthUser(string email, string userName) : base(userName)
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="AuthUser"/> class.
-        /// </summary>
-        public AuthUser()
-        { }
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="AuthUser"/> class with the specified email address.
-        /// </summary>
-        /// <param name="email">The email address of the new <see cref="AuthUser"/>.</param>
-        public AuthUser(string email) : this(email, email)
-        { }
-
-        /// <summary>
-        /// Creates a new instance of the <see cref="AuthUser"/> class with the specified email address and user name.
-        /// </summary>
-        /// <param name="email">The email address of the new <see cref="AuthUser"/>.</param>
-        /// <param name="userName">The user name of the new <see cref="AuthUser"/>.</param>
-        public AuthUser(string email, string userName) : base(userName)
-        {
-            Email = email;
-        }
-
-        ///<inheritdoc/>
-        string? IRequiresAuthorization.Name => Email;
-
-        /// <summary>
-        /// The claims that this application user possesses.
-        /// </summary>
-        public virtual ICollection<IdentityUserClaim<string>> Claims { get; } = new List<IdentityUserClaim<string>>();
+        Email = email;
     }
+
+    ///<inheritdoc/>
+    string? IRequiresAuthorization.Name => Email;
+
+    /// <summary>
+    /// The claims that this application user possesses.
+    /// </summary>
+    public virtual ICollection<IdentityUserClaim<string>> Claims { get; } = [];
 }

--- a/Authorization.Core/IAuthorizationManager.cs
+++ b/Authorization.Core/IAuthorizationManager.cs
@@ -10,12 +10,12 @@ public interface IAuthorizationManager
     /// <summary>
     /// Returns a list of all claims defined by the application.
     /// </summary>
-    List<string> DefinedClaims { get; }
+    IReadOnlyCollection<string> DefinedClaims { get; }
 
     /// <summary>
     /// Returns a list of all Guids defined by the application.
     /// </summary>
-    List<string> DefinedGuids { get; }
+    IReadOnlyCollection<string> DefinedGuids { get; }
 
     /// <summary>
     /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/> 

--- a/Authorization.Core/IAuthorizationManager.cs
+++ b/Authorization.Core/IAuthorizationManager.cs
@@ -1,66 +1,63 @@
-﻿using System.Collections.Generic;
-using System.Security.Claims;
-using System.Threading.Tasks;
+﻿using System.Security.Claims;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Defines the methods and properties exposed by the <see cref="AuthorizationManager"/> class.
+/// </summary>
+public interface IAuthorizationManager
 {
     /// <summary>
-    /// Defines the methods and properties exposed by the <see cref="AuthorizationManager"/> class.
+    /// Returns a list of all claims defined by the application.
     /// </summary>
-    public interface IAuthorizationManager
-    {
-        /// <summary>
-        /// Returns a list of all claims defined by the application.
-        /// </summary>
-        List<string> DefinedClaims { get; }
+    List<string> DefinedClaims { get; }
 
-        /// <summary>
-        /// Returns a list of all Guids defined by the application.
-        /// </summary>
-        List<string> DefinedGuids { get; }
+    /// <summary>
+    /// Returns a list of all Guids defined by the application.
+    /// </summary>
+    List<string> DefinedGuids { get; }
 
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/> 
-        /// for the specified <paramref name="resource"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
-        /// <param name="resource">The resource to be tested against.</param>
-        /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
-        /// <returns>
-        /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </returns>
-        Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, object resource, AppClaimRequirement claimRequirement);
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/> 
+    /// for the specified <paramref name="resource"/>.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
+    /// <param name="resource">The resource to be tested against.</param>
+    /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
+    /// <returns>
+    /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </returns>
+    Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, object resource, AppClaimRequirement claimRequirement);
 
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
-        /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
-        /// <returns>
-        /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
-        /// </returns>
-        Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement);
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the authenticated user.</param>
+    /// <param name="claimRequirement">The requirement that must be met for authorization to be granted.</param>
+    /// <returns>
+    /// An <see cref="AuthorizationResult"/> specifying whether the <paramref name="principal"/> meets the specified <paramref name="claimRequirement"/>.
+    /// </returns>
+    Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal principal, AppClaimRequirement claimRequirement);
 
-        /// <summary>
-        /// Returns an indication of whether the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>. 
-        /// </summary>
-        /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the user.</param>
-        /// <param name="requiredClaims">The claims that the <paramref name="principal"/> must have for authorization to be granted.</param>
-        /// <returns>
-        /// <em>true</em>, if the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>; otherwise, <em>false</em>.
-        /// </returns>
-        Task<bool> IsAuthorizedAsync(ClaimsPrincipal principal, params string[] requiredClaims);
+    /// <summary>
+    /// Returns an indication of whether the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>. 
+    /// </summary>
+    /// <param name="principal">The <see cref="ClaimsPrincipal"/> representing the user.</param>
+    /// <param name="requiredClaims">The claims that the <paramref name="principal"/> must have for authorization to be granted.</param>
+    /// <returns>
+    /// <em>true</em>, if the specified <paramref name="principal"/> has the specified <paramref name="requiredClaims"/>; otherwise, <em>false</em>.
+    /// </returns>
+    Task<bool> IsAuthorizedAsync(ClaimsPrincipal principal, params string[] requiredClaims);
 
-        /// <summary>
-        /// Removes the UserRoleCache entry of the specified user.
-        /// </summary>
-        /// <param name="userId">The ID of the User whose UserRoleCache entry is to be removed.</param>
-        void RefreshUser(string userId);
+    /// <summary>
+    /// Removes the UserRoleCache entry of the specified user.
+    /// </summary>
+    /// <param name="userId">The ID of the User whose UserRoleCache entry is to be removed.</param>
+    void RefreshUser(string userId);
 
-        /// <summary>
-        /// Removes the RoleClaimCache entry of the specified role.
-        /// </summary>
-        /// <param name="roleId">The ID of the Role whose RoleClaimCache entry is to be removed.</param>
-        void RefreshRole(string roleId);
-    }
+    /// <summary>
+    /// Removes the RoleClaimCache entry of the specified role.
+    /// </summary>
+    /// <param name="roleId">The ID of the Role whose RoleClaimCache entry is to be removed.</param>
+    void RefreshRole(string roleId);
 }

--- a/Authorization.Core/IAuthorizationServices.cs
+++ b/Authorization.Core/IAuthorizationServices.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-
-namespace CRFricke.Authorization.Core;
+﻿namespace CRFricke.Authorization.Core;
 
 /// <summary>
 /// Defines the service methods exposed by the <see cref="AuthorizationManager"/> class.

--- a/Authorization.Core/IDefinesClaims.cs
+++ b/Authorization.Core/IDefinesClaims.cs
@@ -8,5 +8,5 @@ public interface IDefinesClaims
     /// <summary>
     /// Returns all Claims defined for a resource.
     /// </summary>
-    List<string> DefinedClaims { get; }
+    IReadOnlyCollection<string> DefinedClaims { get; }
 }

--- a/Authorization.Core/IDefinesClaims.cs
+++ b/Authorization.Core/IDefinesClaims.cs
@@ -1,15 +1,12 @@
-﻿using System.Collections.Generic;
+﻿namespace CRFricke.Authorization.Core;
 
-namespace CRFricke.Authorization.Core
+/// <summary>
+/// Used to identify the classes that define the application's Claims.
+/// </summary>
+public interface IDefinesClaims
 {
     /// <summary>
-    /// Used to identify the classes that define the application's Claims.
+    /// Returns all Claims defined for a resource.
     /// </summary>
-    public interface IDefinesClaims
-    {
-        /// <summary>
-        /// Returns all Claims defined for a resource.
-        /// </summary>
-        List<string> DefinedClaims { get; }
-    }
+    List<string> DefinedClaims { get; }
 }

--- a/Authorization.Core/IDefinesGuids.cs
+++ b/Authorization.Core/IDefinesGuids.cs
@@ -1,15 +1,12 @@
-﻿using System.Collections.Generic;
+﻿namespace CRFricke.Authorization.Core;
 
-namespace CRFricke.Authorization.Core
+/// <summary>
+/// Used to identify the classes that define the application's GUIDs.
+/// </summary>
+public interface IDefinesGuids
 {
     /// <summary>
-    /// Used to identify the classes that define the application's GUIDs.
+    /// Returns all GUIDs defined for a resource.
     /// </summary>
-    public interface IDefinesGuids
-    {
-        /// <summary>
-        /// Returns all GUIDs defined for a resource.
-        /// </summary>
-        List<string> DefinedGuids { get; }
-    }
+    List<string> DefinedGuids { get; }
 }

--- a/Authorization.Core/IDefinesGuids.cs
+++ b/Authorization.Core/IDefinesGuids.cs
@@ -8,5 +8,5 @@ public interface IDefinesGuids
     /// <summary>
     /// Returns all GUIDs defined for a resource.
     /// </summary>
-    List<string> DefinedGuids { get; }
+    IReadOnlyCollection<string> DefinedGuids { get; }
 }

--- a/Authorization.Core/IRepository.cs
+++ b/Authorization.Core/IRepository.cs
@@ -3,10 +3,12 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
 
+#pragma warning disable CA1716 // Identifiers should not match keywords
+
 namespace CRFricke.Authorization.Core;
 
 /// <summary>
-/// Defines the <see cref="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes" /> referenced by Entity Framework entities.
+/// Defines the <see cref="DynamicallyAccessedMemberTypes" /> referenced by Entity Framework entities.
 /// </summary>
 public partial interface IRepository
 {
@@ -14,13 +16,13 @@ public partial interface IRepository
     /// Specifies the types of members that are dynamically accessed.
     /// </summary>
     public const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
-        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
-        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces;
+        DynamicallyAccessedMemberTypes.PublicConstructors
+        | DynamicallyAccessedMemberTypes.NonPublicConstructors
+        | DynamicallyAccessedMemberTypes.PublicProperties
+        | DynamicallyAccessedMemberTypes.PublicFields
+        | DynamicallyAccessedMemberTypes.NonPublicProperties
+        | DynamicallyAccessedMemberTypes.NonPublicFields
+        | DynamicallyAccessedMemberTypes.Interfaces;
 }
 
 /// <summary>

--- a/Authorization.Core/IRepository.cs
+++ b/Authorization.Core/IRepository.cs
@@ -1,80 +1,76 @@
 ﻿using CRFricke.Authorization.Core.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Defines the <see cref="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes" /> referenced by Entity Framework entities.
+/// </summary>
+public partial interface IRepository
 {
     /// <summary>
-    /// Defines the <see cref="System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes" /> referenced by Entity Framework entities.
+    /// Specifies the types of members that are dynamically accessed.
     /// </summary>
-    public partial interface IRepository
-    {
-        /// <summary>
-        /// Specifies the types of members that are dynamically accessed.
-        /// </summary>
-        public const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
-            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
-            | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces;
-    }
+    public const DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes =
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
+        | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces;
+}
+
+/// <summary>
+/// Defines the methods and properties exposed by the database repository.
+/// </summary>
+/// <typeparam name="TUser">The <see cref="Type"/> of user objects. The Type must be or extend from <see cref="AuthUser"/>.</typeparam>
+/// <typeparam name="TRole">The <see cref="Type"/> of role objects. The Type must be or extend from <see cref="AuthRole"/>.</typeparam>
+public partial interface IRepository<
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
+    [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole >
+    where TUser : AuthUser
+    where TRole : AuthRole
+{
+    /// <summary>
+    /// The collection of roles contained in the database repository.
+    /// </summary>
+    DbSet<TRole> Roles { get; }
 
     /// <summary>
-    /// Defines the methods and properties exposed by the database repository.
+    /// The collection of users contained in the database repository.
     /// </summary>
-    /// <typeparam name="TUser">The <see cref="Type"/> of user objects. The Type must be or extend from <see cref="AuthUser"/>.</typeparam>
-    /// <typeparam name="TRole">The <see cref="Type"/> of role objects. The Type must be or extend from <see cref="AuthRole"/>.</typeparam>
-    public partial interface IRepository<
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TUser,
-        [DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TRole >
-        where TUser : AuthUser
-        where TRole : AuthRole
-    {
-        /// <summary>
-        /// The collection of roles contained in the database repository.
-        /// </summary>
-        DbSet<TRole> Roles { get; }
+    DbSet<TUser> Users { get; }
 
-        /// <summary>
-        /// The collection of users contained in the database repository.
-        /// </summary>
-        DbSet<TUser> Users { get; }
+    /// <summary>
+    /// The collection of role claims contained in the database repository.
+    /// </summary>
+    DbSet<IdentityRoleClaim<string>> RoleClaims { get; }
 
-        /// <summary>
-        /// The collection of role claims contained in the database repository.
-        /// </summary>
-        DbSet<IdentityRoleClaim<string>> RoleClaims { get; }
+    /// <summary>
+    /// The collection of user claims contained in the database repository.
+    /// </summary>
+    DbSet<IdentityUserClaim<string>> UserClaims { get; }
 
-        /// <summary>
-        /// The collection of user claims contained in the database repository.
-        /// </summary>
-        DbSet<IdentityUserClaim<string>> UserClaims { get; }
+    /// <summary>
+    /// Creates a <see cref="DbSet{TEntity}"/> that can be used to query and save instances of TEntity.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of entity for which a set should be returned.</typeparam>
+    /// <returns>A set for the given entity type.</returns>
+    DbSet<TEntity> Set<[DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TEntity>() where TEntity : class;
 
-        /// <summary>
-        /// Creates a <see cref="DbSet{TEntity}"/> that can be used to query and save instances of TEntity.
-        /// </summary>
-        /// <typeparam name="TEntity">The type of entity for which a set should be returned.</typeparam>
-        /// <returns>A set for the given entity type.</returns>
-        DbSet<TEntity> Set<[DynamicallyAccessedMembers(IRepository.DynamicallyAccessedMemberTypes)] TEntity>() where TEntity : class;
-
-        /// <summary>
-        /// Saves all changes made in this context to the repository.Use 'await' to ensure that 
-        /// any asynchronous operations have completed before calling another method on this context.
-        /// </summary>
-        /// <param name="cancellationToken">
-        /// A System.Threading.CancellationToken to observe while waiting for the task to complete.
-        /// </param>
-        /// <returns>
-        /// A task that represents the asynchronous save operation. The task result contains
-        /// the number of state entries written to the database.
-        /// </returns>
-        Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
-    }
+    /// <summary>
+    /// Saves all changes made in this context to the repository.Use 'await' to ensure that 
+    /// any asynchronous operations have completed before calling another method on this context.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// A System.Threading.CancellationToken to observe while waiting for the task to complete.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous save operation. The task result contains
+    /// the number of state entries written to the database.
+    /// </returns>
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/Authorization.Core/IRequiresAuthorization.cs
+++ b/Authorization.Core/IRequiresAuthorization.cs
@@ -11,7 +11,7 @@ public interface IRequiresAuthorization
     string Id { get; }
 
     /// <summary>
-    /// Tha name of the resource requiring authorization.
+    /// The name of the resource requiring authorization.
     /// </summary>
     string? Name { get; }
 }

--- a/Authorization.Core/IRequiresAuthorization.cs
+++ b/Authorization.Core/IRequiresAuthorization.cs
@@ -1,18 +1,17 @@
-﻿namespace CRFricke.Authorization.Core
+﻿namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Interface used to mark application resources that require authorization.
+/// </summary>
+public interface IRequiresAuthorization
 {
     /// <summary>
-    /// Interface used to mark application resources that require authorization.
+    /// The ID of the resource requiring authorization.
     /// </summary>
-    public interface IRequiresAuthorization
-    {
-        /// <summary>
-        /// The ID of the resource requiring authorization.
-        /// </summary>
-        string Id { get; }
+    string Id { get; }
 
-        /// <summary>
-        /// Tha name of the resource requiring authorization.
-        /// </summary>
-        string? Name { get; }
-    }
+    /// <summary>
+    /// Tha name of the resource requiring authorization.
+    /// </summary>
+    string? Name { get; }
 }

--- a/Authorization.Core/IResourceAuthorizationHandler.cs
+++ b/Authorization.Core/IResourceAuthorizationHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace CRFricke.Authorization.Core;
+﻿namespace CRFricke.Authorization.Core;
 
 /// <summary>
 /// Classes that implement this interface perform additional authorization checks for a specified resource.

--- a/Authorization.Core/IdentityBuilderExtensions.cs
+++ b/Authorization.Core/IdentityBuilderExtensions.cs
@@ -3,120 +3,118 @@ using CRFricke.EF.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// Provides extension methods for the <see cref="IdentityBuilder"/> class.
+/// </summary>
+public static class IdentityBuilderExtensions
 {
     /// <summary>
-    /// Provides extension methods for the <see cref="IdentityBuilder"/> class.
+    /// Adds AccessRight based authorization services to the <see cref="IServiceCollection"/>.
     /// </summary>
-    public static class IdentityBuilderExtensions
+    /// <param name="builder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
+    /// <param name="dbInitializationOption">
+    /// The <see cref="DbInitializationOption"/> to be used to initialize the database.
+    /// </param>
+    /// <returns>The <see cref="IdentityBuilder"/> instance this method extends.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062:DynamicallyAccessedMembers", Justification = "AddScoped() 'implementationType' parameter is DBContext and always has available public constructor.")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:DynamicallyAccessedMembers", Justification = "AuthorizationManager<,> & IRepository<,> definitions have required DynamicallyAccessedMembers attributes.")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2076:DynamicallyAccessedMembers", Justification = "Type arguments are validated at runtime via VerifyTypeDerivesFrom to ensure they derive from required base types (AuthUser/AuthRole).")]
+    public static IdentityBuilder AddAccessRightBasedAuthorization(this IdentityBuilder builder, DbInitializationOption dbInitializationOption = DbInitializationOption.Migrate)
     {
-        /// <summary>
-        /// Adds AccessRight based authorization services to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <param name="builder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
-        /// <param name="dbInitializationOption">
-        /// The <see cref="DbInitializationOption"/> to be used to initialize the database.
-        /// </param>
-        /// <returns>The <see cref="IdentityBuilder"/> instance this method extends.</returns>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062:DynamicallyAccessedMembers", Justification = "AddScoped() 'implementationType' parameter is DBContext and always has available public constructor.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:DynamicallyAccessedMembers", Justification = "AuthorizationManager<,> & IRepository<,> definitions have required DynamicallyAccessedMembers attributes.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2076:DynamicallyAccessedMembers", Justification = "Type arguments are validated at runtime via VerifyTypeDerivesFrom to ensure they derive from required base types (AuthUser/AuthRole).")]
-        public static IdentityBuilder AddAccessRightBasedAuthorization(this IdentityBuilder builder, DbInitializationOption dbInitializationOption = DbInitializationOption.Migrate)
+        Type contextType;
+
+        using (var serviceProvider = builder.Services.BuildServiceProvider())
         {
-            Type contextType;
+            var storeType = builder.RoleType != null
+                ? serviceProvider.GetRequiredService(typeof(IRoleStore<>).MakeGenericType(builder.RoleType)).GetType()
+                : serviceProvider.GetRequiredService(typeof(IUserStore<>).MakeGenericType(builder.UserType)).GetType();
 
-            using (var serviceProvider = builder.Services.BuildServiceProvider())
-            {
-                var storeType = builder.RoleType != null
-                    ? serviceProvider.GetRequiredService(typeof(IRoleStore<>).MakeGenericType(builder.RoleType)).GetType()
-                    : serviceProvider.GetRequiredService(typeof(IUserStore<>).MakeGenericType(builder.UserType)).GetType();
-
-                contextType = storeType.GenericTypeArguments[1];
-            }
-
-            VerifyTypeDerivesFrom(contextType, typeof(AuthDbContext<,>));
-
-            VerifyTypeDerivesFrom(builder.UserType, typeof(AuthUser));
-
-            if (builder.RoleType != null)
-            {
-                VerifyTypeDerivesFrom(builder.RoleType, typeof(AuthRole));
-            }
-
-            var roleType = builder.RoleType ?? typeof(AuthRole);
-
-            var authManagerType = typeof(AuthorizationManager<,>)
-                .MakeGenericType(builder.UserType, roleType);
-            var iRepository = typeof(IRepository<,>)
-                .MakeGenericType(builder.UserType, roleType);
-
-            builder.Services
-                .AddHttpContextAccessor()
-                .AddSingleton<RoleClaimCache>()
-                .AddSingleton<UserRoleCache>()
-                .AddScoped(iRepository, contextType)
-                .AddSingleton(typeof(IAuthorizationManager), authManagerType)
-                .AddSingleton<IAuthorizationPolicyProvider, AppClaimRequirementProvider>()
-                .AddSingleton<IAuthorizationHandler, AppClaimRequirementHandler>()
-                .AddSingleton(
-                    typeof(IResourceAuthorizationHandler<>).MakeGenericType(roleType),
-                    typeof(RoleAuthorizationHandler<>).MakeGenericType(roleType) )
-                .AddSingleton(
-                    typeof(IResourceAuthorizationHandler<>).MakeGenericType(builder.UserType),
-                    typeof(UserAuthorizationHandler<>).MakeGenericType(builder.UserType) )
-                .AddDbInitializer(options =>
-                    options.UseDbContext(contextType, dbInitializationOption)
-                    );
-
-            return builder;
+            contextType = storeType.GenericTypeArguments[1];
         }
 
-        private static void VerifyTypeDerivesFrom(Type type, Type baseType)
+        VerifyTypeDerivesFrom(contextType, typeof(AuthDbContext<,>));
+
+        VerifyTypeDerivesFrom(builder.UserType, typeof(AuthUser));
+
+        if (builder.RoleType != null)
         {
-            if (!TypeDerivesFrom(type, baseType))
-            {
-                throw new InvalidOperationException(
-                    $"'{type}' is not derived from '{baseType}' class."
-                    );
-            }
+            VerifyTypeDerivesFrom(builder.RoleType, typeof(AuthRole));
         }
 
+        var roleType = builder.RoleType ?? typeof(AuthRole);
 
-        /// <summary>
-        /// Determines whether a specified <see cref="Type"/> derives from the specified base Type.
-        /// </summary>
-        /// <param name="type">The <see cref="Type"/> to be checked.</param>
-        /// <param name="baseType">The base <see cref="Type"/> to checked for.</param>
-        /// <returns>
-        /// <em>true</em>, if the <see cref="Type"/> derives from the base Type; otherwise, <em>false</em>.
-        /// </returns>
-        private static bool TypeDerivesFrom(Type? type, Type baseType)
+        var authManagerType = typeof(AuthorizationManager<,>)
+            .MakeGenericType(builder.UserType, roleType);
+        var iRepository = typeof(IRepository<,>)
+            .MakeGenericType(builder.UserType, roleType);
+
+        builder.Services
+            .AddHttpContextAccessor()
+            .AddSingleton<RoleClaimCache>()
+            .AddSingleton<UserRoleCache>()
+            .AddScoped(iRepository, contextType)
+            .AddSingleton(typeof(IAuthorizationManager), authManagerType)
+            .AddSingleton<IAuthorizationPolicyProvider, AppClaimRequirementProvider>()
+            .AddSingleton<IAuthorizationHandler, AppClaimRequirementHandler>()
+            .AddSingleton(
+                typeof(IResourceAuthorizationHandler<>).MakeGenericType(roleType),
+                typeof(RoleAuthorizationHandler<>).MakeGenericType(roleType) )
+            .AddSingleton(
+                typeof(IResourceAuthorizationHandler<>).MakeGenericType(builder.UserType),
+                typeof(UserAuthorizationHandler<>).MakeGenericType(builder.UserType) )
+            .AddDbInitializer(options =>
+                options.UseDbContext(contextType, dbInitializationOption)
+                );
+
+        return builder;
+    }
+
+    private static void VerifyTypeDerivesFrom(Type type, Type baseType)
+    {
+        if (!TypeDerivesFrom(type, baseType))
         {
-            while (type != null)
+            throw new InvalidOperationException(
+                $"'{type}' is not derived from '{baseType}' class."
+                );
+        }
+    }
+
+
+    /// <summary>
+    /// Determines whether a specified <see cref="Type"/> derives from the specified base Type.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> to be checked.</param>
+    /// <param name="baseType">The base <see cref="Type"/> to checked for.</param>
+    /// <returns>
+    /// <em>true</em>, if the <see cref="Type"/> derives from the base Type; otherwise, <em>false</em>.
+    /// </returns>
+    private static bool TypeDerivesFrom(Type? type, Type baseType)
+    {
+        while (type != null)
+        {
+            if (type.Name == baseType.Name)
             {
-                if (type.Name == baseType.Name)
+                if (type.GenericTypeArguments.Length == baseType.GenericTypeArguments.Length)
                 {
-                    if (type.GenericTypeArguments.Length == baseType.GenericTypeArguments.Length)
+                    for (var ix = 0; ix < type.GenericTypeArguments.Length; ix++)
                     {
-                        for (var ix = 0; ix < type.GenericTypeArguments.Length; ix++)
+                        if (!baseType.GenericTypeArguments[ix].IsAssignableFrom(type.GenericTypeArguments[ix]))
                         {
-                            if (!baseType.GenericTypeArguments[ix].IsAssignableFrom(type.GenericTypeArguments[ix]))
-                            {
-                                return false;
-                            }
+                            return false;
                         }
                     }
-
-                    return true;
                 }
 
-                type = type.BaseType;
-            };
+                return true;
+            }
 
-            return false;
-        }
+            type = type.BaseType;
+        };
+
+        return false;
     }
 }

--- a/Authorization.Core/IdentityBuilderExtensions.cs
+++ b/Authorization.Core/IdentityBuilderExtensions.cs
@@ -12,65 +12,67 @@ namespace CRFricke.Authorization.Core;
 /// </summary>
 public static class IdentityBuilderExtensions
 {
-    /// <summary>
-    /// Adds AccessRight based authorization services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="builder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
-    /// <param name="dbInitializationOption">
-    /// The <see cref="DbInitializationOption"/> to be used to initialize the database.
-    /// </param>
-    /// <returns>The <see cref="IdentityBuilder"/> instance this method extends.</returns>
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062:DynamicallyAccessedMembers", Justification = "AddScoped() 'implementationType' parameter is DBContext and always has available public constructor.")]
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:DynamicallyAccessedMembers", Justification = "AuthorizationManager<,> & IRepository<,> definitions have required DynamicallyAccessedMembers attributes.")]
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2076:DynamicallyAccessedMembers", Justification = "Type arguments are validated at runtime via VerifyTypeDerivesFrom to ensure they derive from required base types (AuthUser/AuthRole).")]
-    public static IdentityBuilder AddAccessRightBasedAuthorization(this IdentityBuilder builder, DbInitializationOption dbInitializationOption = DbInitializationOption.Migrate)
+    extension(IdentityBuilder builder)
     {
-        Type contextType;
-
-        using (var serviceProvider = builder.Services.BuildServiceProvider())
+        /// <summary>
+        /// Adds AccessRight based authorization services to the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="dbInitializationOption">
+        /// The <see cref="DbInitializationOption"/> to be used to initialize the database.
+        /// </param>
+        /// <returns>The <see cref="IdentityBuilder"/> instance this method extends.</returns>
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062:DynamicallyAccessedMembers", Justification = "AddScoped() 'implementationType' parameter is DBContext and always has available public constructor.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:DynamicallyAccessedMembers", Justification = "AuthorizationManager<,> & IRepository<,> definitions have required DynamicallyAccessedMembers attributes.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2076:DynamicallyAccessedMembers", Justification = "Type arguments are validated at runtime via VerifyTypeDerivesFrom to ensure they derive from required base types (AuthUser/AuthRole).")]
+        public IdentityBuilder AddAccessRightBasedAuthorization(DbInitializationOption dbInitializationOption = DbInitializationOption.Migrate)
         {
-            var storeType = builder.RoleType != null
-                ? serviceProvider.GetRequiredService(typeof(IRoleStore<>).MakeGenericType(builder.RoleType)).GetType()
-                : serviceProvider.GetRequiredService(typeof(IUserStore<>).MakeGenericType(builder.UserType)).GetType();
+            Type contextType;
 
-            contextType = storeType.GenericTypeArguments[1];
+            using (var serviceProvider = builder.Services.BuildServiceProvider())
+            {
+                var storeType = builder.RoleType != null
+                    ? serviceProvider.GetRequiredService(typeof(IRoleStore<>).MakeGenericType(builder.RoleType)).GetType()
+                    : serviceProvider.GetRequiredService(typeof(IUserStore<>).MakeGenericType(builder.UserType)).GetType();
+
+                contextType = storeType.GenericTypeArguments[1];
+            }
+
+            VerifyTypeDerivesFrom(contextType, typeof(AuthDbContext<,>));
+
+            VerifyTypeDerivesFrom(builder.UserType, typeof(AuthUser));
+
+            if (builder.RoleType != null)
+            {
+                VerifyTypeDerivesFrom(builder.RoleType, typeof(AuthRole));
+            }
+
+            var roleType = builder.RoleType ?? typeof(AuthRole);
+
+            var authManagerType = typeof(AuthorizationManager<,>)
+                .MakeGenericType(builder.UserType, roleType);
+            var iRepository = typeof(IRepository<,>)
+                .MakeGenericType(builder.UserType, roleType);
+
+            builder.Services
+                .AddHttpContextAccessor()
+                .AddSingleton<RoleClaimCache>()
+                .AddSingleton<UserRoleCache>()
+                .AddScoped(iRepository, contextType)
+                .AddSingleton(typeof(IAuthorizationManager), authManagerType)
+                .AddSingleton<IAuthorizationPolicyProvider, AppClaimRequirementProvider>()
+                .AddSingleton<IAuthorizationHandler, AppClaimRequirementHandler>()
+                .AddSingleton(
+                    typeof(IResourceAuthorizationHandler<>).MakeGenericType(roleType),
+                    typeof(RoleAuthorizationHandler<>).MakeGenericType(roleType))
+                .AddSingleton(
+                    typeof(IResourceAuthorizationHandler<>).MakeGenericType(builder.UserType),
+                    typeof(UserAuthorizationHandler<>).MakeGenericType(builder.UserType))
+                .AddDbInitializer(options =>
+                    options.UseDbContext(contextType, dbInitializationOption)
+                    );
+
+            return builder;
         }
-
-        VerifyTypeDerivesFrom(contextType, typeof(AuthDbContext<,>));
-
-        VerifyTypeDerivesFrom(builder.UserType, typeof(AuthUser));
-
-        if (builder.RoleType != null)
-        {
-            VerifyTypeDerivesFrom(builder.RoleType, typeof(AuthRole));
-        }
-
-        var roleType = builder.RoleType ?? typeof(AuthRole);
-
-        var authManagerType = typeof(AuthorizationManager<,>)
-            .MakeGenericType(builder.UserType, roleType);
-        var iRepository = typeof(IRepository<,>)
-            .MakeGenericType(builder.UserType, roleType);
-
-        builder.Services
-            .AddHttpContextAccessor()
-            .AddSingleton<RoleClaimCache>()
-            .AddSingleton<UserRoleCache>()
-            .AddScoped(iRepository, contextType)
-            .AddSingleton(typeof(IAuthorizationManager), authManagerType)
-            .AddSingleton<IAuthorizationPolicyProvider, AppClaimRequirementProvider>()
-            .AddSingleton<IAuthorizationHandler, AppClaimRequirementHandler>()
-            .AddSingleton(
-                typeof(IResourceAuthorizationHandler<>).MakeGenericType(roleType),
-                typeof(RoleAuthorizationHandler<>).MakeGenericType(roleType) )
-            .AddSingleton(
-                typeof(IResourceAuthorizationHandler<>).MakeGenericType(builder.UserType),
-                typeof(UserAuthorizationHandler<>).MakeGenericType(builder.UserType) )
-            .AddDbInitializer(options =>
-                options.UseDbContext(contextType, dbInitializationOption)
-                );
-
-        return builder;
     }
 
     private static void VerifyTypeDerivesFrom(Type type, Type baseType)
@@ -113,7 +115,8 @@ public static class IdentityBuilderExtensions
             }
 
             type = type.BaseType;
-        };
+        }
+        ;
 
         return false;
     }

--- a/Authorization.Core/LoggerExtensions.cs
+++ b/Authorization.Core/LoggerExtensions.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace CRFricke.Authorization.Core;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Debug,
+        Message = "{ClassName} for \"{AppClaimRequirement}\" not met for user '{UserName}' - user ID is null.")]
+    internal static partial void LogClaimRequirementNotMetNoUserId(
+        this ILogger logger,
+        string className,
+        AppClaimRequirement appClaimRequirement,
+        string? userName);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Information,
+        Message = "{ClassName} of \"{Claim}\" for {ResourceType} '{ObjectName}' not met by '{UserName}' - restricted operation on system User or Role.")]
+    internal static partial void LogClaimRequirementNotMetSystemObject(
+        this ILogger logger,
+        string className,
+        string claim,
+        string resourceType,
+        string objectName,
+        string? userName);
+
+    [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Debug,
+        Message = "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}' via {RoleName} role.")]
+    internal static partial void LogClaimRequirementMetViaAdministrator(
+        this ILogger logger,
+        string className,
+        AppClaimRequirement appClaimRequirement,
+        string? userName,
+        string roleName);
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Debug,
+        Message = "{ClassName} for \"{AppClaimRequirement}\" met for user '{UserName}'.")]
+    internal static partial void LogClaimRequirementMet(
+        this ILogger logger,
+        string className,
+        AppClaimRequirement appClaimRequirement,
+        string? userName);
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Information,
+        Message = "{RoleType} '{RoleName}' (ID: {RoleId}) has been created.")]
+    internal static partial void LogRoleCreated(
+        this ILogger logger,
+        string roleType,
+        string roleName,
+        string roleId);
+
+    [LoggerMessage(
+        EventId = 6,
+        Level = LogLevel.Information,
+        Message = "{UserType} '{UserEmail}' (ID: {UserId}) has been created.")]
+    internal static partial void LogUserCreated(
+        this ILogger logger,
+        string userType,
+        string userEmail,
+        string userId);
+
+    [LoggerMessage(
+        EventId = 7,
+        Level = LogLevel.Error,
+        Message = "SaveChangesAsync() method failed.")]
+    internal static partial void LogSaveChangesFailed(
+        this ILogger logger,
+        Exception ex);
+
+    [LoggerMessage(
+        EventId = 8,
+        Level = LogLevel.Information,
+        Message = "Fixup successful for {UpdateCount} {UpdateEntity}.")]
+    internal static partial void LogFixupSuccessful(
+        this ILogger logger,
+        int updateCount,
+        string updateEntity);
+
+    [LoggerMessage(
+        EventId = 9,
+        Level = LogLevel.Error,
+        Message = "FixupUserClaimValuesAsync() method failed.")]
+    internal static partial void LogFixupUserClaimValuesFailed(
+        this ILogger logger,
+        Exception ex);
+}

--- a/Authorization.Core/RoleAuthorizationHandler.cs
+++ b/Authorization.Core/RoleAuthorizationHandler.cs
@@ -29,14 +29,14 @@ public class RoleAuthorizationHandler<TRole> : IResourceAuthorizationHandler<TRo
         // Principal.UserId() is verified before the ResourceAuthorizationHandler is called.
         var principalId = context.Principal.UserId()!;
 
-        var principalRoles = await context.AuthorizationServices.GetUserRolesAsync(principalId);
+        var principalRoles = await context.AuthorizationServices.GetUserRolesAsync(principalId).ConfigureAwait(false);
         if (principalRoles.Contains(SysGuids.Role.Administrator))
         {
             return AuthorizationResult.Success();
         }
 
-        var principalClaims = await context.AuthorizationServices.GetRoleClaimsAsync(principalRoles);
-        var roleClaims = await context.AuthorizationServices.GetRoleClaimsAsync(role.Id);
+        var principalClaims = await context.AuthorizationServices.GetRoleClaimsAsync(principalRoles).ConfigureAwait(false);
+        var roleClaims = await context.AuthorizationServices.GetRoleClaimsAsync(role.Id).ConfigureAwait(false);
 
         if (roleClaims.IsSubsetOf(principalClaims))
         {

--- a/Authorization.Core/RoleAuthorizationHandler.cs
+++ b/Authorization.Core/RoleAuthorizationHandler.cs
@@ -1,7 +1,4 @@
 ﻿using CRFricke.Authorization.Core.Data;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace CRFricke.Authorization.Core;
 

--- a/Authorization.Core/RoleClaimCache.cs
+++ b/Authorization.Core/RoleClaimCache.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// A local in-memory cache used to store the claims associated with an ApplicationRole.
+/// </summary>
+internal class RoleClaimCache : IMemoryCache
 {
-    /// <summary>
-    /// A local in-memory cache used to store the claims associated with an ApplicationRole.
-    /// </summary>
-    internal class RoleClaimCache : IMemoryCache
-    {
-        readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    readonly MemoryCache _cache = new(new MemoryCacheOptions());
 
-        ///<inheritdoc/>
-        public virtual ICacheEntry CreateEntry(object key) => _cache.CreateEntry(key);
+    ///<inheritdoc/>
+    public virtual ICacheEntry CreateEntry(object key) => _cache.CreateEntry(key);
 
-        ///<inheritdoc/>
-        public virtual void Dispose() => _cache.Dispose();
+    ///<inheritdoc/>
+    public virtual void Dispose() => _cache.Dispose();
 
-        ///<inheritdoc/>
-        public virtual void Remove(object key) => _cache.Remove(key);
+    ///<inheritdoc/>
+    public virtual void Remove(object key) => _cache.Remove(key);
 
-        ///<inheritdoc/>
-        public virtual bool TryGetValue(object key, out object? value) => _cache.TryGetValue(key, out value);
-    }
+    ///<inheritdoc/>
+    public virtual bool TryGetValue(object key, out object? value) => _cache.TryGetValue(key, out value);
 }

--- a/Authorization.Core/SysClaims.cs
+++ b/Authorization.Core/SysClaims.cs
@@ -4,12 +4,13 @@ using System.Security.Claims;
 
 namespace CRFricke.Authorization.Core;
 
+#pragma warning disable CA1033 // Interface methods should be callable by child types
 #pragma warning disable CA1034 // Nested types should not be visible
 
 /// <summary>
 /// Defines the Claims used by the Authorization system.
 /// </summary>
-public class SysClaims
+public static class SysClaims
 {
     /// <summary>
     /// The claim type of the claims the Authorization.Core library uses.
@@ -76,13 +77,13 @@ public class SysClaims
         /// <summary>
         /// Returns a list of all Claims defined for Role entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims =
+        public static readonly IReadOnlyCollection<string> DefinedClaims =
         [
             Create, Delete, Read, Update, List, UpdateClaims
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
+        IReadOnlyCollection<string> IDefinesClaims.DefinedClaims => DefinedClaims;
     }
 
     /// <summary>
@@ -125,12 +126,12 @@ public class SysClaims
         /// <summary>
         /// Returns a list of all Claims defined for User entities.
         /// </summary>
-        public static readonly List<string> DefinedClaims =
+        public static readonly IReadOnlyCollection<string> DefinedClaims =
         [
             Create, Delete, Read, Update, List, UpdateClaims
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
+        IReadOnlyCollection<string> IDefinesClaims.DefinedClaims => DefinedClaims;
     }
 }

--- a/Authorization.Core/SysClaims.cs
+++ b/Authorization.Core/SysClaims.cs
@@ -1,136 +1,136 @@
 ﻿using CRFricke.Authorization.Core.Attributes;
 using Microsoft.AspNetCore.Identity;
-using System.Collections.Generic;
 using System.Security.Claims;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+#pragma warning disable CA1034 // Nested types should not be visible
+
+/// <summary>
+/// Defines the Claims used by the Authorization system.
+/// </summary>
+public class SysClaims
 {
     /// <summary>
-    /// Defines the Claims used by the Authorization system.
+    /// The claim type of the claims the Authorization.Core library uses.
     /// </summary>
-    public class SysClaims
+    public const string ClaimType = ClaimTypes.AuthorizationDecision;
+
+
+    /// <summary>
+    /// Creates a new IdentityRoleClaim using the specified Role ID and claim value.
+    /// </summary>
+    /// <param name="roleId">The ID of the Role being assigned the claim.</param>
+    /// <param name="claimValue">The claim value.</param>
+    /// <returns>A new IdentityRoleClaim with the specified values.</returns>
+    public static IdentityRoleClaim<string> CreateRoleClaim(string roleId, string claimValue)
+        => new() { RoleId = roleId, ClaimType = ClaimType, ClaimValue = claimValue };
+
+    /// <summary>
+    /// Creates a new IdentityUserClaim using the specified User ID and claim value.
+    /// </summary>
+    /// <param name="userId">The ID of the User being assigned the claim.</param>
+    /// <param name="claimValue">The claim value.</param>
+    /// <returns>A new IdentityUserClaim with the specified values.</returns>
+    public static IdentityUserClaim<string> CreateUserClaim(string userId, string claimValue)
+        => new() { UserId = userId, ClaimType = ClaimTypes.Role, ClaimValue = claimValue };
+
+
+    /// <summary>
+    /// Defines the claims associated with the Role entity.
+    /// </summary>
+    public class Role : IDefinesClaims
     {
         /// <summary>
-        /// The claim type of the claims the Authorization.Core library uses.
+        /// The user can create Role entities.
         /// </summary>
-        public const string ClaimType = ClaimTypes.AuthorizationDecision;
-
+        public const string Create = "Role.Create";
 
         /// <summary>
-        /// Creates a new IdentityRoleClaim using the specified Role ID and claim value.
+        /// The user can read Role entities.
         /// </summary>
-        /// <param name="roleId">The ID of the Role being assigned the claim.</param>
-        /// <param name="claimValue">The claim value.</param>
-        /// <returns>A new IdentityRoleClaim with the specified values.</returns>
-        public static IdentityRoleClaim<string> CreateRoleClaim(string roleId, string claimValue)
-            => new() { RoleId = roleId, ClaimType = ClaimType, ClaimValue = claimValue };
+        public const string Read = "Role.Read";
 
         /// <summary>
-        /// Creates a new IdentityUserClaim using the specified User ID and claim value.
+        /// The user can update Role entities.
         /// </summary>
-        /// <param name="userId">The ID of the User being assigned the claim.</param>
-        /// <param name="claimValue">The claim value.</param>
-        /// <returns>A new IdentityUserClaim with the specified values.</returns>
-        public static IdentityUserClaim<string> CreateUserClaim(string userId, string claimValue)
-            => new() { UserId = userId, ClaimType = ClaimTypes.Role, ClaimValue = claimValue };
-
+        public const string Update = "Role.Update";
 
         /// <summary>
-        /// Defines the claims associated with the Role entity.
+        /// The user can delete Role entities.
         /// </summary>
-        public class Role : IDefinesClaims
-        {
-            /// <summary>
-            /// The user can create Role entities.
-            /// </summary>
-            public const string Create = "Role.Create";
-
-            /// <summary>
-            /// The user can read Role entities.
-            /// </summary>
-            public const string Read = "Role.Read";
-
-            /// <summary>
-            /// The user can update Role entities.
-            /// </summary>
-            public const string Update = "Role.Update";
-
-            /// <summary>
-            /// The user can delete Role entities.
-            /// </summary>
-            [RestrictedClaim]
-            public const string Delete = "Role.Delete";
-
-            /// <summary>
-            /// The user can list Role entities.
-            /// </summary>
-            public const string List = "Role.List";
-
-            /// <summary>
-            /// The user can update the claims collection of Role entities.
-            /// </summary>
-            [RestrictedClaim]
-            public const string UpdateClaims = "Role.UpdateClaims";
-
-            /// <summary>
-            /// Returns a list of all Claims defined for Role entities.
-            /// </summary>
-            public static readonly List<string> DefinedClaims = new()
-            {
-                Create, Delete, Read, Update, List, UpdateClaims
-            };
-
-            ///<inheritdoc/>
-            List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
-        }
+        [RestrictedClaim]
+        public const string Delete = "Role.Delete";
 
         /// <summary>
-        /// Defines the claims associated with the User entity.
+        /// The user can list Role entities.
         /// </summary>
-        public class User : IDefinesClaims
-        {
-            /// <summary>
-            /// The user can create User entities.
-            /// </summary>
-            public const string Create = "User.Create";
+        public const string List = "Role.List";
 
-            /// <summary>
-            /// The user can read User entities.
-            /// </summary>
-            public const string Read = "User.Read";
+        /// <summary>
+        /// The user can update the claims collection of Role entities.
+        /// </summary>
+        [RestrictedClaim]
+        public const string UpdateClaims = "Role.UpdateClaims";
 
-            /// <summary>
-            /// The user can update User entities.
-            /// </summary>
-            public const string Update = "User.Update";
+        /// <summary>
+        /// Returns a list of all Claims defined for Role entities.
+        /// </summary>
+        public static readonly List<string> DefinedClaims =
+        [
+            Create, Delete, Read, Update, List, UpdateClaims
+        ];
 
-            /// <summary>
-            /// The user can delete User entities.
-            /// </summary>
-            [RestrictedClaim]
-            public const string Delete = "User.Delete";
+        ///<inheritdoc/>
+        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
+    }
 
-            /// <summary>
-            /// The user can list User entities.
-            /// </summary>
-            public const string List = "User.List";
+    /// <summary>
+    /// Defines the claims associated with the User entity.
+    /// </summary>
+    public class User : IDefinesClaims
+    {
+        /// <summary>
+        /// The user can create User entities.
+        /// </summary>
+        public const string Create = "User.Create";
 
-            /// <summary>
-            /// The user can update the claims collection of User entities.
-            /// </summary>
-            [RestrictedClaim]
-            public const string UpdateClaims = "User.UpdateClaims";
+        /// <summary>
+        /// The user can read User entities.
+        /// </summary>
+        public const string Read = "User.Read";
 
-            /// <summary>
-            /// Returns a list of all Claims defined for User entities.
-            /// </summary>
-            public static readonly List<string> DefinedClaims = new()
-            {
-                Create, Delete, Read, Update, List, UpdateClaims
-            };
+        /// <summary>
+        /// The user can update User entities.
+        /// </summary>
+        public const string Update = "User.Update";
 
-            ///<inheritdoc/>
-            List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
-        }
+        /// <summary>
+        /// The user can delete User entities.
+        /// </summary>
+        [RestrictedClaim]
+        public const string Delete = "User.Delete";
+
+        /// <summary>
+        /// The user can list User entities.
+        /// </summary>
+        public const string List = "User.List";
+
+        /// <summary>
+        /// The user can update the claims collection of User entities.
+        /// </summary>
+        [RestrictedClaim]
+        public const string UpdateClaims = "User.UpdateClaims";
+
+        /// <summary>
+        /// Returns a list of all Claims defined for User entities.
+        /// </summary>
+        public static readonly List<string> DefinedClaims =
+        [
+            Create, Delete, Read, Update, List, UpdateClaims
+        ];
+
+        ///<inheritdoc/>
+        List<string> IDefinesClaims.DefinedClaims => DefinedClaims;
     }
 }

--- a/Authorization.Core/SysGuids.cs
+++ b/Authorization.Core/SysGuids.cs
@@ -1,11 +1,12 @@
 ﻿namespace CRFricke.Authorization.Core;
 
+#pragma warning disable CA1033 // Interface methods should be callable by child types
 #pragma warning disable CA1034 // Nested types should not be visible
 
 /// <summary>
 /// Defines the Guids used by the Authorization system.
 /// </summary>
-public class SysGuids
+public static class SysGuids
 {
     /// <summary>
     /// The Guids of the system Roles.
@@ -20,13 +21,13 @@ public class SysGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for Role entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             Administrator
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 
     /// <summary>
@@ -42,12 +43,12 @@ public class SysGuids
         /// <summary>
         /// Returns a list of all GUIDs defined for User entities.
         /// </summary>
-        public static readonly List<string> DefinedGuids =
+        public static readonly IReadOnlyCollection<string> DefinedGuids =
         [
             Administrator
         ];
 
         ///<inheritdoc/>
-        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+        IReadOnlyCollection<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 }

--- a/Authorization.Core/SysGuids.cs
+++ b/Authorization.Core/SysGuids.cs
@@ -1,54 +1,53 @@
-﻿using System.Collections.Generic;
+﻿namespace CRFricke.Authorization.Core;
 
-namespace CRFricke.Authorization.Core
+#pragma warning disable CA1034 // Nested types should not be visible
+
+/// <summary>
+/// Defines the Guids used by the Authorization system.
+/// </summary>
+public class SysGuids
 {
     /// <summary>
-    /// Defines the Guids used by the Authorization system.
+    /// The Guids of the system Roles.
     /// </summary>
-    public class SysGuids
+    public class Role : IDefinesGuids
     {
         /// <summary>
-        /// The Guids of the system Roles.
+        /// The Guid assigned to the Administrator Role.
         /// </summary>
-        public class Role : IDefinesGuids
-        {
-            /// <summary>
-            /// The Guid assigned to the Administrator Role.
-            /// </summary>
-            public const string Administrator = "3f1dfcb9-7088-4877-8352-7a6e43063650";
-
-            /// <summary>
-            /// Returns a list of all GUIDs defined for Role entities.
-            /// </summary>
-            public static readonly List<string> DefinedGuids = new()
-            {
-                Administrator
-            };
-
-            ///<inheritdoc/>
-            List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
-        }
+        public const string Administrator = "3f1dfcb9-7088-4877-8352-7a6e43063650";
 
         /// <summary>
-        /// The Guids of the system Users.
+        /// Returns a list of all GUIDs defined for Role entities.
         /// </summary>
-        public class User : IDefinesGuids
-        {
-            /// <summary>
-            /// The Guid assigned to the Administrator User account.
-            /// </summary>
-            public const string Administrator = "8156bb9b-f56e-4f83-8a11-b0418b843e9b";
+        public static readonly List<string> DefinedGuids =
+        [
+            Administrator
+        ];
 
-            /// <summary>
-            /// Returns a list of all GUIDs defined for User entities.
-            /// </summary>
-            public static readonly List<string> DefinedGuids = new()
-            {
-                Administrator
-            };
+        ///<inheritdoc/>
+        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
+    }
 
-            ///<inheritdoc/>
-            List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
-        }
+    /// <summary>
+    /// The Guids of the system Users.
+    /// </summary>
+    public class User : IDefinesGuids
+    {
+        /// <summary>
+        /// The Guid assigned to the Administrator User account.
+        /// </summary>
+        public const string Administrator = "8156bb9b-f56e-4f83-8a11-b0418b843e9b";
+
+        /// <summary>
+        /// Returns a list of all GUIDs defined for User entities.
+        /// </summary>
+        public static readonly List<string> DefinedGuids =
+        [
+            Administrator
+        ];
+
+        ///<inheritdoc/>
+        List<string> IDefinesGuids.DefinedGuids => DefinedGuids;
     }
 }

--- a/Authorization.Core/UserAuthorizationHandler.cs
+++ b/Authorization.Core/UserAuthorizationHandler.cs
@@ -29,20 +29,20 @@ public class UserAuthorizationHandler<TUser> : IResourceAuthorizationHandler<TUs
         // Principal.UserId() is verified before the ResourceAuthorizationHandler is called.
         var principalId = context.Principal.UserId()!;
 
-        var principalRoles = await context.AuthorizationServices.GetUserRolesAsync(principalId);
+        var principalRoles = await context.AuthorizationServices.GetUserRolesAsync(principalId).ConfigureAwait(false);
         if (principalRoles.Contains(SysGuids.Role.Administrator))
         {
             return AuthorizationResult.Success();
         }
 
-        var userRoles = await context.AuthorizationServices.GetUserRolesAsync(user.Id);
+        var userRoles = await context.AuthorizationServices.GetUserRolesAsync(user.Id).ConfigureAwait(false);
         if (userRoles.Contains(SysGuids.Role.Administrator))
         {
             return AuthorizationResult.Elevation([nameof(SysGuids.Role.Administrator)]);
         }
 
-        var principalClaims = await context.AuthorizationServices.GetRoleClaimsAsync(principalRoles);
-        var userClaims = await context.AuthorizationServices.GetRoleClaimsAsync(userRoles);
+        var principalClaims = await context.AuthorizationServices.GetRoleClaimsAsync(principalRoles).ConfigureAwait(false);
+        var userClaims = await context.AuthorizationServices.GetRoleClaimsAsync(userRoles).ConfigureAwait(false);
 
         if (userClaims.IsSubsetOf(principalClaims))
         {

--- a/Authorization.Core/UserAuthorizationHandler.cs
+++ b/Authorization.Core/UserAuthorizationHandler.cs
@@ -1,7 +1,4 @@
 ﻿using CRFricke.Authorization.Core.Data;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace CRFricke.Authorization.Core;
 

--- a/Authorization.Core/UserRoleCache.cs
+++ b/Authorization.Core/UserRoleCache.cs
@@ -1,24 +1,23 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 
-namespace CRFricke.Authorization.Core
+namespace CRFricke.Authorization.Core;
+
+/// <summary>
+/// A local in-memory cache used to associate ApplicationRoles with ApplicationUsers.
+/// </summary>
+internal class UserRoleCache : IMemoryCache
 {
-    /// <summary>
-    /// A local in-memory cache used to associate ApplicationRoles with ApplicationUsers.
-    /// </summary>
-    internal class UserRoleCache : IMemoryCache
-    {
-        readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    readonly MemoryCache _cache = new(new MemoryCacheOptions());
 
-        ///<inheritdoc/>
-        public virtual ICacheEntry CreateEntry(object key) => _cache.CreateEntry(key);
+    ///<inheritdoc/>
+    public virtual ICacheEntry CreateEntry(object key) => _cache.CreateEntry(key);
 
-        ///<inheritdoc/>
-        public virtual void Dispose() => _cache.Dispose();
+    ///<inheritdoc/>
+    public virtual void Dispose() => _cache.Dispose();
 
-        ///<inheritdoc/>
-        public virtual void Remove(object key) => _cache.Remove(key);
+    ///<inheritdoc/>
+    public virtual void Remove(object key) => _cache.Remove(key);
 
-        ///<inheritdoc/>
-        public virtual bool TryGetValue(object key, out object? value) => _cache.TryGetValue(key, out value);
-    }
+    ///<inheritdoc/>
+    public virtual bool TryGetValue(object key, out object? value) => _cache.TryGetValue(key, out value);
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Common properties for all projects -->
   <PropertyGroup>
-	<!--<AnalysisMode>All</AnalysisMode>-->
+	<AnalysisMode>All</AnalysisMode>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<LangVersion>latest</LangVersion>
 	<Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,42 @@
+<Project>
+
+  <!-- Common properties for all projects -->
+  <PropertyGroup>
+	<!--<AnalysisMode>All</AnalysisMode>-->
+	<ImplicitUsings>enable</ImplicitUsings>
+	<LangVersion>latest</LangVersion>
+	<Nullable>enable</Nullable>
+	<TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Package metadata -->
+  <PropertyGroup>
+	<Authors>Chuck Fricke</Authors>
+	<Company>Fricke Consulting</Company>
+	<Copyright>Copyright © Chuck Fricke $([System.DateTime]::Now.ToString(yyyy))</Copyright>
+	<PackageIcon>icon.png</PackageIcon>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	<PackageProjectUrl>https://github.com/CRFricke/Authorization.Core</PackageProjectUrl>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <!-- GitHub Actions CI/CD configurations -->
+  <!-- For 'push' workflow, we embed the symbol package in the DLL and push the nupkg to github.com -->
+  <PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'push'">
+	<DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <!-- For 'release' workflow, we create a separate symbol package and push both to nuget.org -->
+  <PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'release'">
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <!-- To get a "deterministic build" for our NuGet package -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+	<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,20 +3,22 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Core dependencies -->
-    <PackageVersion Include="CRFricke.EF.Core.Utilities" Version="10.0.0-beta2.0" />
-    <PackageVersion Include="CRFricke.Test.Support" Version="10.0.0-beta3.0" />
     <!-- ASP.NET Core Identity -->
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
+	  
     <!-- Entity Framework Core -->
+    <PackageVersion Include="CRFricke.EF.Core.Utilities" Version="10.0.0-beta2.0" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />
+	  
     <!-- Testing -->
     <PackageVersion Include="coverlet.MTP" Version="10.0.0" />
+    <PackageVersion Include="CRFricke.Test.Support" Version="10.0.0-beta3.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Playwright.TestAdapter" Version="1.59.0" />
     <PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.59.0" />
@@ -25,6 +27,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+	  
     <!-- Build tools -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,4 @@
 {
-  "sdk": {
-    "version": "9.0.100",
-    "rollForward": "latestMajor"
-  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
This pull request updates all logging to use `LoggerMessage` source generation, which provides high performance logging and compile-time safety.

It also refactors and improves the test suite for the `AuthorizationManager` by standardizing test method names, ensuring deterministic comparisons in assertions, and enhancing string comparison robustness. It also introduces new `.editorconfig` rules for code analysis and removes unnecessary properties from the test project configuration.

Test improvements and refactoring:
- Standardized all test method names in `AuthorizationManagerTests.cs` to a consistent `TestXXAsync`/`TestXX` format for readability and maintainability. [[1]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7R14-R28) [[2]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L43-R48) [[3]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L84-R89) [[4]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L120-R121) [[5]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L160-R161) [[6]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L204-R205) [[7]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L217-R227) [[8]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L248-R249) [[9]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L270-R271) [[10]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L302-R303) [[11]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L355-R360) [[12]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L414-R419) [[13]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L474-R475) [[14]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L506-R507) [[15]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L557-R562) [[16]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L613-R614) [[17]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L650-R651) [[18]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L687-R688) [[19]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L703-R704) [[20]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L735-R744) [[21]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L775-R784) [[22]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L840-R841) [[23]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L872-R881)
- Updated all relevant `Assert.Equal` calls to compare ordered claim collections, ensuring deterministic and reliable test results regardless of collection order. [[1]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L43-R48) [[2]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L84-R89) [[3]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L355-R360) [[4]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L414-R419) [[5]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L557-R562)
- Enhanced string comparison assertions to use `StringComparison.Ordinal` for stricter and culture-invariant checks. [[1]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L217-R227) [[2]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L735-R744) [[3]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L775-R784) [[4]](diffhunk://#diff-541d603e81d8fafd4685cef9efbc8c272a1cdbf6542ef32808727c2cb00efac7L872-R881)

Configuration and code quality:
- Added `.editorconfig` rules to set severity for code analysis rules CA1034 (nested types visibility) and CA1873 (logging performance).
- Removed unnecessary properties (`TargetFramework`, `ImplicitUsings`, `Nullable`) from the test project file `Authorization.Core.Tests.csproj`, likely relying on defaults or central configuration.
