### PR TITLE
Refactor URI handling in tests and update package versions

### DIFF
--- a/Authorization.Core.UI.Tests.Infrastructure/WebAppFactory.cs
+++ b/Authorization.Core.UI.Tests.Infrastructure/WebAppFactory.cs
@@ -7,5 +7,5 @@ public class WebAppFactory : WebApplicationFactory<Program, ApplicationDbContext
 {
     public override string HostingEnvironment => "IntegrationTests";
 
-    public override string HostUrl => "http://AuthCoreUi.dev.localhost";
+    public override Uri HostUri => new("http://AuthCoreUi.dev.localhost");
 }

--- a/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
+++ b/Authorization.Core.UI.Tests.Integration/PageAccessTests.cs
@@ -56,83 +56,94 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
         ArgumentNullException.ThrowIfNull(factory);
 
         WebAppFactory = factory;
-        HostUrl = factory.HostUrl;
+        HostUri = factory.HostUri;
     }
 
     public WebAppFactory WebAppFactory { get; }
 
-    private string HostUrl { get; }
+    private Uri HostUri { get; }
 
 
     [Theory(DisplayName = "Can access Management page via friendly area name ")]
     [MemberData(nameof(Test01Data))]
-    public async Task PageAccessTest01(string endpoint, bool needsId)
+    public async Task Test01Async(string endpoint, bool needsId)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
 
         var client = CreateClientWithAuthenticationScheme();
+
+        var uriBuilder = new UriBuilder(HostUri)
+        {
+            Path = endpoint
+        };
 
         if (needsId)
         {
             var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
-            endpoint += $"?id={id}";
+            uriBuilder.Query = $"id={id}";
         }
 
-        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(uriBuilder.Uri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact(DisplayName = "Can access customer page actually located in friendly name area")]
-    public async Task PageAccessTest02()
+    public async Task Test02Async()
     {
         var client = CreateClientWithAuthenticationScheme(
             nameof(AppGuids.Role.CalendarManager)
             );
+        var uriEndpoint = new Uri(HostUri, "/Admin/Calendar");
 
-        var response = await client.GetAsync(new Uri("/Admin/Calendar", UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(uriEndpoint, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Theory(DisplayName = "Can access Management pages in default area ")]
     [MemberData(nameof(Test03Data))]
-    public async Task PageAccessTest03Async(string endpoint, bool needsId)
+    public async Task Test03Async(string endpoint, bool needsId)
     {
         var client = CreateClientWithAuthenticationScheme();
+
+        var uriBuilder = new UriBuilder(HostUri)
+        {
+            Path = endpoint
+        };
 
         if (needsId)
         {
             var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
-            endpoint += $"?id={id}";
+            uriBuilder.Query = $"id={id}";
         }
 
-        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(uriBuilder.Uri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Theory(DisplayName = "Redirects to AccessDenied page without proper claim ")]
     [MemberData(nameof(Test04Data))]
-    public async Task PageAccessTest04Async(string endpoint)
+    public async Task Test04Async(string endpoint)
     {
         var client = WebAppFactory.CreateClient(new WebApplicationFactoryClientOptions
         {
-            AllowAutoRedirect = false, BaseAddress = new(HostUrl)
+            AllowAutoRedirect = false, BaseAddress = HostUri
         });
 
-        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(HostUri, endpoint), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
     }
 
     [Theory(DisplayName = "Can access management page with proper claim ")]
     [MemberData(nameof(Test05Data))]
-    public async Task PageAccessTest05Async(string endpoint, string claim, bool needsId)
+    public async Task Test05Async(string endpoint, string claim, bool needsId)
     {
         using var scope = WebAppFactory.Services.CreateScope();
         var authManager = scope.ServiceProvider.GetRequiredService<IAuthorizationManager>();
@@ -148,42 +159,47 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
         var client = CreateClientWithAuthenticationScheme(
             nameof(AppGuids.Role.DocumentManager)
             );
+        var uriBuilder = new UriBuilder(HostUri)
+        {
+            Path = endpoint
+        };
 
         if (needsId)
         {
             var id = (endpoint.Contains("Role", StringComparison.Ordinal))
                 ? AppGuids.Role.CalendarManager
                 : AppGuids.User.CalendarGuy;
-            endpoint += $"?id={id}";
+            uriBuilder.Query = $"id={id}";
         }
 
-        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(uriBuilder.Uri, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Theory(DisplayName = "Returns NotFound for null Id ")]
     [MemberData(nameof(Test06Data))]
-    public async Task PageAccessTest06Async(string endpoint)
+    public async Task Test06Async(string endpoint)
     {
         var client = CreateClientWithAuthenticationScheme(
             nameof(SysGuids.Role.Administrator)
             );
 
-        var response = await client.GetAsync(new Uri(endpoint, UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(new Uri(HostUri, endpoint), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Theory(DisplayName = "Returns NotFound for non-existing Id ")]
     [MemberData(nameof(Test06Data))]
-    public async Task PageAccessTest07Async(string endpoint)
+    public async Task Test07Async(string endpoint)
     {
         var client = CreateClientWithAuthenticationScheme(
             nameof(SysGuids.Role.Administrator)
             );
+        var uriEndpoint = new Uri(HostUri, $"{endpoint}?Id={Guid.Empty}");
 
-        var response = await client.GetAsync(new Uri($"{endpoint}?Id={Guid.Empty}", UriKind.Relative), TestContext.Current.CancellationToken);
+        var response = await client.GetAsync(uriEndpoint, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -202,7 +218,7 @@ public class PageAccessTests : IClassFixture<WebAppFactory>
         }).CreateClient(new()
         {
             AllowAutoRedirect = allowRedirect,
-            BaseAddress = new(HostUrl)
+            BaseAddress = HostUri
         });
 
         client.DefaultRequestHeaders.Authorization =

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,25 +9,22 @@
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-	  
     <!-- Entity Framework Core -->
-    <PackageVersion Include="CRFricke.EF.Core.Utilities" Version="10.0.0-beta2.0" />
-	<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="CRFricke.EF.Core.Utilities" Version="10.0.0-beta3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />
-	  
     <!-- Testing -->
     <PackageVersion Include="coverlet.MTP" Version="10.0.0" />
-    <PackageVersion Include="CRFricke.Test.Support" Version="10.0.0-beta3.0" />
+    <PackageVersion Include="CRFricke.Test.Support" Version="10.0.0-beta4.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Playwright.TestAdapter" Version="1.59.0" />
     <PackageVersion Include="Microsoft.Playwright.Xunit.v3" Version="1.59.0" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.2" />
     <PackageVersion Include="MockQueryable.Moq" Version="10.0.5" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-	  
     <!-- Build tools -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>


### PR DESCRIPTION
This pull request refactors the integration test infrastructure and test code to consistently use `Uri` and `HostUri` instead of string-based URLs, and updates several package dependencies. The changes improve type safety and clarity in URI handling throughout the test suite.

Refactoring to use `Uri` and `HostUri`:

* Changed `WebAppFactory` to expose a `HostUri` property of type `Uri` instead of a string `HostUrl`. (`Authorization.Core.UI.Tests.Infrastructure/WebAppFactory.cs`)
* Updated all test classes and methods in `PageAccessTests` to use `HostUri` and `Uri` objects, replacing string-based URL handling with `UriBuilder` and `Uri` constructors for request endpoints. (`Authorization.Core.UI.Tests.Integration/PageAccessTests.cs`) [[1]](diffhunk://#diff-86e77cf054e5235eb2c8aa82619025c6dea29b8b15b070e43d0ed31ae4cf4b8eL59-R146) [[2]](diffhunk://#diff-86e77cf054e5235eb2c8aa82619025c6dea29b8b15b070e43d0ed31ae4cf4b8eR162-R202) [[3]](diffhunk://#diff-86e77cf054e5235eb2c8aa82619025c6dea29b8b15b070e43d0ed31ae4cf4b8eL205-R221)

Test method renaming and improvements:

* Renamed test methods in `PageAccessTests` to a more concise and consistent naming pattern (e.g., `Test01Async` instead of `PageAccessTest01`). (`Authorization.Core.UI.Tests.Integration/PageAccessTests.cs`) [[1]](diffhunk://#diff-86e77cf054e5235eb2c8aa82619025c6dea29b8b15b070e43d0ed31ae4cf4b8eL59-R146) [[2]](diffhunk://#diff-86e77cf054e5235eb2c8aa82619025c6dea29b8b15b070e43d0ed31ae4cf4b8eR162-R202)

Dependency updates:

* Updated `CRFricke.EF.Core.Utilities` to version `10.0.0-beta3.0`, `CRFricke.Test.Support` to `10.0.0-beta4.0`, and `Microsoft.Testing.Platform` to `2.2.2` in `Directory.Packages.props`.